### PR TITLE
add compressors

### DIFF
--- a/basics.lib
+++ b/basics.lib
@@ -50,6 +50,7 @@ closed source license or any other license if you decide so.
 ma = library("maths.lib");
 ro = library("routes.lib");
 ba = library("basics.lib"); // so functions here can be copy/pasted out
+fi = library("filters.lib");
 
 declare name "Faust Basic Element Library";
 declare version "0.1";
@@ -1207,11 +1208,14 @@ selectoutn(n, s) = _ <: par(i, n, *(s==i));
 // Provides various operations on the last N samples using a high order
 // `slidingReduce(op,N,maxN,disabledVal,x)`` fold-like function:
 //
-// * `slidingSumN(n,maxn)`: the sliding sum of the last n input samples
-// * `slidingMaxN(n,maxn)`: the sliding max of the last n input samples
-// * `slidingMinN(n,maxn)`: the sliding min of the last n input samples
-// * `slidingMeanN(n,maxn)`: the sliding mean of the last n input samples
-// * `slidingRMSn(n,maxn)`: the sliding RMS of the last n input samples
+// * `slidingSum(n)`: the sliding sum of the last n input samples, CPU-light
+// * `slidingSump(n,maxn)`: the sliding sum of the last n input samples, numerically stable "forever"
+// * `slidingMax(n,maxn)`: the sliding max of the last n input samples
+// * `slidingMin(n,maxn)`: the sliding min of the last n input samples
+// * `slidingMean(n)`: the sliding mean of the last n input samples, CPU-light
+// * `slidingMeanp(n,maxn)`: the sliding mean of the last n input samples, numerically stable "forever"
+// * `slidingRMS(n)`: the sliding RMS of the last n input samples, CPU-light
+// * `slidingRMSp(n,maxn)`: the sliding RMS of the last n input samples, numerically stable "forever"
 //
 // #### Working Principle
 //
@@ -1410,17 +1414,17 @@ with {
       (1,x) => x;
       (N,x) => op(fixedDelayOp(N/2,x), fixedDelayOp(N/2,x)@(N/2));
     };
-    
+
     // The sum of all the sizes of the previous blocks
     sumOfPrevBlockSizes(N,maxN,0) = 0;
     sumOfPrevBlockSizes(N,maxN,i) = (subseq((allBlockSizes(N,maxN)),0,i):>_);
     allBlockSizes(N,maxN) = par(i, maxNrBits, (pow2(i)) * isUsed(i));
     maxNrBits = int2nrOfBits(maxN);
-    
+
     // Apply <op> to <N> parallel input signals
     combine(2) = op;
     combine(N) = op(combine(N-1),_);
-    
+
     // Decide wether or not to use a certain value, based on N
     // Basically only the second <select2> is needed,
     // but this version also works for N == 0
@@ -1431,7 +1435,7 @@ with {
         select2(isUsed(i), disabledVal,_),
         _
       );
-      
+
     // useVal(i) =
     //     select2(isUsed(i), disabledVal,_);
     isUsed(i) = take(i+1,(int2bin(N,maxN)));
@@ -1447,14 +1451,33 @@ with {
     int2nrOfBits(maxN) = int(floor(log(maxN)/log(2))+1);
 };
 
-
-//------------------------------`(ba.)slidingSumN`------------------------------
+//------------------------------`(ba.)slidingSum`------------------------------
 // The sliding sum of the last n input samples.
+//
+// It will eventually run into numerical trouble when there is a persistent dc component.
+// If that matters in your application, use the more CPU-intensive (ba.)slidinSump.
 //
 // #### Usage
 //
 // ```
-// _ : slidingSumN(N,maxN) : _
+// _ : slidingSum(N) : _
+// ```
+//
+// Where:
+//
+// * `N`: the number of values to process
+//------------------------------------------------------------------------------
+slidingSum(n) = fi.integrator <: _, _@int(max(0,n)) :> -;
+
+//------------------------------`(ba.)slidingSump`------------------------------
+// The sliding sum of the last n input samples.
+//
+// It uses a lot more CPU then (ba.)slidingSum(n,maxn), but is numerically stable "forever" in return.
+//
+// #### Usage
+//
+// ```
+// _ : slidingSump(N,maxN) : _
 // ```
 //
 // Where:
@@ -1462,7 +1485,7 @@ with {
 // * `N`: the number of values to process
 // * `maxN`: the maximum number of values to process, needs to be a power of 2
 //------------------------------------------------------------------------------
-slidingSumN(n,maxn) = slidingReduce(+,n,maxn,0);
+slidingSump(n,maxn) = slidingReduce(+,n,maxn,0);
 
 
 //----------------------------`(ba.)slidingMaxN`--------------------------------
@@ -1479,16 +1502,15 @@ slidingSumN(n,maxn) = slidingReduce(+,n,maxn,0);
 // * `N`: the number of values to process
 // * `maxN`: the maximum number of values to process, needs to be a power of 2
 //------------------------------------------------------------------------------
-slidingMaxN(n,maxn) = slidingReduce(max,n,maxn,-(ma.INFINITY));
+slidingMax(n,maxn) = slidingReduce(max,n,maxn,-(ma.INFINITY));
 
-
-//---------------------------`(ba.)slidingSumN`---------------------------------
+//----------------------------`(ba.)slidingMin`--------------------------------
 // The sliding minimum of the last n input samples.
 //
 // #### Usage
 //
 // ```
-// _ : slidingMinN(N,maxN) : _
+// _ : slidingMin(N,maxN) : _
 // ```
 //
 // Where:
@@ -1496,16 +1518,35 @@ slidingMaxN(n,maxn) = slidingReduce(max,n,maxn,-(ma.INFINITY));
 // * `N`: the number of values to process
 // * `maxN`: the maximum number of values to process, needs to be a power of 2
 //------------------------------------------------------------------------------
-slidingMinN(n,maxn) = slidingReduce(min,n,maxn,ma.INFINITY);
+slidingMin(n,maxn) = slidingReduce(min,n,maxn,ma.INFINITY);
 
-
-//----------------------------`(ba.)slidingMeanN`-------------------------------
+//----------------------------`(ba.)slidingMean`-------------------------------
 // The sliding mean of the last n input samples.
 //
+// It will eventually run into numerical trouble when there is a persistent dc component.
+// If that matters in your application, use the more CPU-intensive (ba.)slidinRMSp.
+//
 // #### Usage
 //
 // ```
-// _ : slidingMeanN(N,maxN) : _
+// _ : slidingMean(N,maxN) : _
+// ```
+//
+// Where:
+//
+// * `N`: the number of values to process
+//------------------------------------------------------------------------------
+slidingMean(n) = slidingSum(n)/n;
+
+//----------------------------`(ba.)slidingMeanp`-------------------------------
+// The sliding mean of the last n input samples.
+//
+// It uses a lot more CPU then (ba.)slidingMean(n,maxn), but is numerically stable "forever" in return.
+//
+// #### Usage
+//
+// ```
+// _ : slidingMeanp(N,maxN) : _
 // ```
 //
 // Where:
@@ -1513,16 +1554,37 @@ slidingMinN(n,maxn) = slidingReduce(min,n,maxn,ma.INFINITY);
 // * `N`: the number of values to process
 // * `maxN`: the maximum number of values to process, needs to be a power of 2
 //------------------------------------------------------------------------------
-slidingMeanN(n,maxn) = slidingSumN(n,maxn)/n;
+slidingMeanp(n,maxn) = slidingSump(n,maxn)/n;
 
 
-//---------------------------`(ba.)slidingRMSn`---------------------------------
+//---------------------------`(ba.)slidingRMS`---------------------------------
 // The root mean square of the last n input samples.
 //
+// It will eventually run into numerical trouble when there is a persistent dc component.
+// If that matters in your application, use the more CPU-intensive (ba.)slidinRMSp.
+
+//
 // #### Usage
 //
 // ```
-// _ : slidingRMSn(N,maxN) : _
+// _ : slidingRMS(N) : _
+// ```
+//
+// Where:
+//
+// * `N`: the number of values to process
+//------------------------------------------------------------------------------
+slidingRMS(n) = pow(2):slidingMean(n) : sqrt;
+
+//---------------------------`(ba.)slidingRMSp`---------------------------------
+// The root mean square of the last n input samples.
+//
+// It uses a lot more CPU then (ba.)slidingRMS(n,maxn), but is numerically stable "forever" in return.
+//
+// #### Usage
+//
+// ```
+// _ : slidingRMSp(N,maxN) : _
 // ```
 //
 // Where:
@@ -1530,8 +1592,7 @@ slidingMeanN(n,maxn) = slidingSumN(n,maxn)/n;
 // * `N`: the number of values to process
 // * `maxN`: the maximum number of values to process, needs to be a power of 2
 //------------------------------------------------------------------------------
-slidingRMSn(n,maxn) = pow(2):slidingMeanN(n,maxn) : sqrt;
-
+slidingRMSp(n,maxn) = pow(2):slidingMeanp(n,maxn) : sqrt;
 
 //////////////////////////////////Deprecated Functions////////////////////////////////////
 // This section implements functions that used to be in music.lib but that are now

--- a/compressors.lib
+++ b/compressors.lib
@@ -37,10 +37,542 @@ closed source license or any other license if you decide so.
 ba = library("basics.lib");
 si = library("signals.lib");
 an = library("analyzers.lib");
-
+ro = library("routes.lib");
 
 declare name "Faust Compressor Effect Library";
 declare version "0.0";
+//=============================Functions Reference========================================
+//========================================================================================
+
+//--------------------`(co.)peak_compression_gain_mono`-------------------
+// Mono dynamic range compressor gain computer.
+// `peak_compression_gain_mono` is a standard Faust function
+//
+// #### Usage
+//
+// ```
+// _ : peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost) : _
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in faust
+
+// Sometimes even bigger ratios are usefull:
+// For example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+
+// Author: Bart Brouns
+// License: GPLv3
+
+// note: si.lag_ud has a bug where if you compile with standard precision,
+// down is 0 and prePost is 1, you go into infinite GR and stay there
+peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost) =
+  abs:ba.bypass(prePost,si.lag_ud(att,rel)) : ba.linear2db : gain_computer(strength,thresh,knee):ba.bypass((prePost*-1)+1,si.lag_ud(rel,att)) : ba.db2linear
+with {
+  gain_computer(strength,thresh,knee,level) =
+    select3((level>(thresh-(knee/2)))+(level>(thresh+(knee/2))),
+            0,
+            ((level-thresh+(knee/2)):pow(2)/(2*knee)) ,
+            (level-thresh)
+           ) : max(0)*-strength;
+};
+
+
+//--------------------`(co.)peak_compression_gain_N_chan`-------------------
+// N channel dynamic range compressor gain computer.
+// `peak_compression_gain_N_chan` is a standard Faust function
+//
+// #### Usage
+//
+// ```
+// si.bus(N) : peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) : si.bus(N)
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
+// * `N`: the number of channels of the compressor
+
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in faust
+
+// Sometimes even bigger ratios are usefull:
+// For example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+// Author: Bart Brouns
+// License: GPLv3
+
+// generalise compression gains for N channels.
+// first we define a mono version:
+peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,1) =
+  peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost);
+
+// The actual N-channel version:
+// Calculate the maximum gain reduction of N channels,
+// and then crossfade between that and each channel's own gain reduction,
+// to link/unlink channels
+peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) =
+  par(i, N, peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost))
+  <:(si.bus(N),(ba.minimum(N)<:si.bus(N))):ro.interleave(N,2):par(i,N,(ba.crossfade(link)));
+
+
+//--------------------`(co.)FFcompressor_N_chan`-------------------
+// feed forward N channel dynamic range compressor.
+// `FFcompressor_N_chan` is a standard Faust function
+//
+// #### Usage
+//
+// ```
+// si.bus(N) : FFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,meter,N) : si.bus(N)
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
+// * `meter`: a gain reduction meter. It can be implemented like so:
+// meter = _<:(_, (ba.linear2db:max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;
+// * `N`: the number of channels of the compressor
+
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in faust
+
+// Sometimes even bigger ratios are usefull:
+// For example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+// Author: Bart Brouns
+// License: GPLv3
+
+// feed forward compressor
+FFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,meter,N) =
+  (si.bus(N) <:
+    (peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N),si.bus(N))
+  )
+  :(ro.interleave(N,2):par(i,N,meter*_));
+
+//--------------------`(co.)FBcompressor_N_chan`-------------------
+// feed back N channel dynamic range compressor.
+// `FBcompressor_N_chan` is a standard Faust function
+//
+// #### Usage
+//
+// ```
+// si.bus(N) : FBcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,meter,N) : si.bus(N)
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
+// * `meter`: a gain reduction meter. It can be implemented like so:
+// meter = _<:(_, (ba.linear2db:max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;
+// * `N`: the number of channels of the compressor
+
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in faust
+
+// Sometimes even bigger ratios are usefull:
+// For example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+// Author: Bart Brouns
+// License: GPLv3
+
+FBcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,meter,N) =
+  (
+    (peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N),si.bus(N))
+    :(ro.interleave(N,2):par(i,N,meter*_))
+  )~si.bus(N);
+
+//--------------------`(co.)FFFBcompressor_N_chan`-------------------
+// feed forward / feed back N channel dynamic range compressor.
+// the feedback part has a much higher strength, so they end up sounding similar
+// `FFFBcompressor_N_chan` is a standard Faust function
+//
+// #### Usage
+//
+// ```
+// si.bus(N) : FFFBcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) : si.bus(N)
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
+// * `FFFB`: fade between feed forward (0) and feed back (1) compression.
+// * `meter`: a gain reduction meter. It can be implemented like so:
+// meter = _<:(_, (ba.linear2db:max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;
+// * `N`: the number of channels of the compressor
+
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in faust
+
+// Sometimes even bigger ratios are usefull:
+// For example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+// Author: Bart Brouns
+// License: GPLv3
+
+FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) =
+  si.bus(N) <: si.bus(N*2):
+  (
+    ((
+      (par(i, 2, peak_compression_gain_N_chan(strength*(1+((i==0)*2)),thresh,att,rel,knee,prePost,link,N)):ro.interleave(N,2):par(i, N, ba.crossfade(FBFF)))
+      ,si.bus(N))
+      :(ro.interleave(N,2):par(i,N,meter*_))
+    )~si.bus(N)
+  );
+
+
+//--------------------`(co.)RMS_compression_gain_mono`-------------------
+// Mono RMS dynamic range compressor gain computer.
+// `RMS_compression_gain_mono` is a standard Faust function
+//
+// #### Usage
+//
+// ```
+// _ : RMS_compression_gain_mono(strength,thresh,att,rel,knee,prePost) : _
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in faust
+
+// Sometimes even bigger ratios are usefull:
+// For example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+// Author: Bart Brouns
+// License: GPLv3
+
+RMS_compression_gain_mono(strength,thresh,att,rel,knee,prePost) =
+  RMS(rel): ba.bypass(prePost,si.lag_ud(att,0)) : ba.linear2db : gain_computer(strength,thresh,knee) : ba.bypass((prePost*-1)+1,si.lag_ud(0,att)) : ba.db2linear
+with {
+  gain_computer(strength,thresh,knee,level) =
+    select3((level>(thresh-(knee/2)))+(level>(thresh+(knee/2))),
+            0,
+            ((level-thresh+(knee/2)):pow(2)/(2*knee)) ,
+            (level-thresh)
+           ) : max(0)*-strength;
+  RMS(time) = ba.slidingRMS(s) with {
+    s = ba.sec2samp(time):int:max(1);
+};
+};
+
+//--------------------`(co.)RMS_compression_gain_N_chan`-------------------
+// RMS N channel dynamic range compressor gain computer.
+// `RMS_compression_gain_N_chan` is a standard Faust function
+//
+// #### Usage
+//
+// ```
+// si.bus(N) : RMS_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) : si.bus(N)
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
+// * `N`: the number of channels of the compressor
+
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in faust
+
+// Sometimes even bigger ratios are usefull:
+// For example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+// Author: Bart Brouns
+// License: GPLv3
+
+RMS_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,1) =
+  RMS_compression_gain_mono(strength,thresh,att,rel,knee,prePost);
+
+RMS_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) =
+  par(i, N, RMS_compression_gain_mono(strength,thresh,att,rel,knee,prePost))
+  <:(si.bus(N),(ba.minimum(N)<:si.bus(N))):ro.interleave(N,2):par(i,N,(ba.crossfade(link)));
+
+
+//--------------------`(co.)RMS_FFFBcompressor_N_chan`-------------------
+// RMS feed forward / feed back N channel dynamic range compressor.
+// the feedback part has a much higher strength, so they end up sounding similar
+// `RMS_FFFBcompressor_N_chan` is a standard Faust function
+//
+// #### Usage
+//
+// ```
+// si.bus(N) : RMS_FFFBcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) : si.bus(N)
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
+// * `FFFB`: fade between feed forward (0) and feed back (1) compression.
+// * `meter`: a gain reduction meter. It can be implemented like so:
+// meter = _<:(_, (ba.linear2db:max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;
+// * `N`: the number of channels of the compressor
+
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in faust
+
+// Sometimes even bigger ratios are usefull:
+// For example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+
+// to save CPU we cheat a bit, in a similar way as in the original libs:
+// instead of crosfading between two sets of gain calculators as above,
+// we take the abs of the audio from both the FF and FB, and crossfade between those,
+// and feed that into one set of gain calculators
+// again the strength is much higher when in FB mode, but implemented differently
+
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+// Author: Bart Brouns
+// License: GPLv3
+
+RMS_FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) =
+  si.bus(N) <: si.bus(N*2):
+  (
+    (
+      (
+        (ro.interleave(N,2):par(i, N*2, abs) :par(i, N, ba.crossfade(FBFF)) : RMS_compression_gain_N_chan(strength*(1+(((FBFF*-1)+1)*1)),thresh,att,rel,knee,prePost,link,N))
+        ,si.bus(N)
+      )
+    :(ro.interleave(N,2):par(i,N,meter*_))
+    )~si.bus(N)
+  );
+
+
+//--------------------`(co.)RMS_FBcompressor_peak_limiter_N_chan`-------------------
+// N channel RMS feed back compressor into peak limiter feeding back into the FB compressor.
+// By combining them this way, they complement each other optimally:
+// The RMS compressor doesn't have to deal with the peaks,
+// and the peak limiter get's spared from the steady state signal.
+// the feedback part has a much higher strength, so they end up sounding similar
+// `RMS_FBcompressor_peak_limiter_N_chan` is a standard Faust function
+//
+// #### Usage
+//
+// ```
+// si.bus(N) : RMS_FBcompressor_peak_limiter_N_chan(strength,thresh,threshLim,att,rel,knee,link,meter,N) : si.bus(N)
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `threshLim`: dB level threshold above which the brick wall limiter kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// this is also used as the release time of the limiter
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// the limiter uses a knee half this size
+// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
+// * `meter`: a gain reduction meter. It can be implemented like so:
+// meter = _<:(_, (ba.linear2db:max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;
+// * `N`: the number of channels of the compressor
+
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in faust
+
+// Sometimes even bigger ratios are usefull:
+// For example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+// Author: Bart Brouns
+// License: GPLv3
+
+RMS_FBcompressor_peak_limiter_N_chan(strength,thresh,threshLim,att,rel,knee,link,meter,N) =
+  (
+    (
+      (
+        (RMS_compression_gain_N_chan(strength,thresh,att,rel,knee,0,link,N))
+        ,si.bus(N)
+      ):(ro.interleave(N,2):par(i,N,meter*_))
+    ):FFcompressor_N_chan(1,threshLim,0,att:min(rel),knee*0.5,0,link,meter,N)
+  )~si.bus(N);
+
+
+//=============================Backward compatibility section=============================
+//========================================================================================
+// These functions are superseded by the ones above.
+// They are included for backward compatibility.
 
 //=============================Functions Reference========================================
 //========================================================================================


### PR DESCRIPTION
Took a while, but here we finally are!  :)

I implemented the suggestions by @josmithiii in https://github.com/grame-cncm/faustlibraries/issues/3:

- omit the N from the names of the variants on slidingReduce
- change slidingSum to the less CPU-intensive version
- add numerically stable "forever" versions
I used the p postfix that @josmithiii  mentioned in the context of protected functions

Let me know if any more changes are needed.