### PR TITLE
Fixup quadosc

### DIFF
--- a/oscillators.lib
+++ b/oscillators.lib
@@ -1255,14 +1255,14 @@ polyblep_triangle(f) = polyblep_square(f) : fi.pole(0.999) : *(4 * f / ma.SR);
 // Authors:
 // Dario Sanfilippo <sanfilippo.dario@gmail.com>
 // and Oleg Nesterov (jos ed.)
-quadosc(f) = tick ~ (_,_) : mem+1,mem with {
+quadosc(f) = tick ~ (_,_) : (!,_*0.5) with {
   k1 = tan(f * ma.PI/ma.SR);
   k2 = 2*k1 / (1 + k1 * k1);
 
   tick(u_0,v_0) = u_1,v_1 with {
     tmp = u_0 - k1 * v_0;
     v_1 = v_0 + k2 * (tmp + 1);
-    u_1 = tmp - k1 * v_1;
+    u_1 = (tmp - k1 * v_1)+impulse;
   };
 };
 


### PR DESCRIPTION
Somehow the initial value of `u` got lost in [the last commit to this function](https://github.com/grame-cncm/faustlibraries/commit/ba34ca657a8c98efc804061c5b2e1d4f7e6bc6ff).

Also it has had 2 outputs all  along, not sure why. I removed the first one, cause the second one was easiest to match with os.osc.

I added a gain correction and removed the delay.
