### PR TITLE
Fixup quadosc

### DIFF
--- a/oscillators.lib
+++ b/oscillators.lib
@@ -1255,14 +1255,14 @@ polyblep_triangle(f) = polyblep_square(f) : fi.pole(0.999) : *(4 * f / ma.SR);
 // Authors:
 // Dario Sanfilippo <sanfilippo.dario@gmail.com>
 // and Oleg Nesterov (jos ed.)
-quadosc(f) = tick ~ (_,_) : mem+1,mem with {
+quadosc(f) = tick ~ (_,_) : (!,_*0.5) with {
   k1 = tan(f * ma.PI/ma.SR);
   k2 = 2*k1 / (1 + k1 * k1);
 
   tick(u_0,v_0) = u_1,v_1 with {
     tmp = u_0 - k1 * v_0;
     v_1 = v_0 + k2 * (tmp + 1);
-    u_1 = tmp - k1 * v_1;
+    u_1 = (tmp - k1 * v_1)+impulse;
   };
 };
 


### PR DESCRIPTION
This a replacement for https://github.com/grame-cncm/faustlibraries/pull/22, since that one was off my master branch, which is not handy, and I don't think it's possible to change which branch a PR uses.