### PR TITLE
Fix map function in hoa.lib

### DIFF
--- a/hoa.lib
+++ b/hoa.lib
@@ -250,8 +250,8 @@ with {
 //-----------------------------------------------------
 map(n, x, r, a)	= encoder(n, x * volume(r), a) : wider(n, ouverture(r))
 with {
-	volume(r) = 1. / (r * r * (r > 1) + (r < 1));
-	ouverture(r) = r * (r < 1) + (r > 1);
+	volume(r) = 1. / (r * r * (r > 1) + (r =< 1));
+	ouverture(r) = r * (r < 1) + (r >= 1);
 };
 
 


### PR DESCRIPTION
This PR fixes the map function that generates an audio glitch when the radius of the source equals one because there is division by zero (volume) and another value (ouverture) jumps to zero.