### PR TITLE
basic 1pole LP and HP filters

### DIFF
--- a/filters.lib
+++ b/filters.lib
@@ -140,6 +140,58 @@ declare dcblocker copyright "Copyright (C) 2003-2019 by Julius O. Smith III <jos
 declare dcblocker license "MIT-style STK-4.3 license";
 dcblocker = zero(1) : pole(0.995);
 
+//-----------------------`(fi.)lp1p`-------------------------------------------
+// Basic one-pole low-pass filter based on Chamberlin's design.
+// 
+// #### Usage
+// 
+// ```
+// _ : lp1p(cf) : _
+// ```
+// 
+// Where:
+//
+// * `cf`: cut-off frequency in Hz
+//
+// #### Reference
+// Hal Chamberlin, Musical Applications of Microprocessor, Sams, 1985.
+//-----------------------------------------------------------------------------
+declare lp1p author "Dario Sanfilippo";
+declare lp1p copyright "Copyright (C) 2020 by Dario Sanfilippo 
+      <sanfilippo.dario@gmail.com>"
+declare lp1p license "MIT-style STK-4.3 license"
+lp1p(cf, x) = x * a0 : pole(b1)
+with {
+      a0 = 1 - b1;
+      b1 = exp(-cf * 2 * ma.PI / ma.SR) : max(0) : min(1);
+};
+
+//-----------------------`(fi.)hp1p`-------------------------------------------
+// Basic one-pole high-pass filter based on Chamberlin's design.
+// 
+// #### Usage
+// 
+// ```
+// _ : hp1p(cf) : _
+// ```
+// 
+// Where:
+//
+// * `cf`: cut-off frequency in Hz
+//
+// #### Reference
+// Hal Chamberlin, Musical Applications of Microprocessor, Sams, 1985.
+//-----------------------------------------------------------------------------
+declare hp1p author "Dario Sanfilippo";
+declare hp1p copyright "Copyright (C) 2020 by Dario Sanfilippo 
+      <sanfilippo.dario@gmail.com>"
+declare hp1p license "MIT-style STK-4.3 license"
+hp1p(cf, x) = x * a0 : pole(b1)
+with {
+      a0 = 1 + b1;
+      b1 = exp((.5 - cf / ma.SR) * -2 * ma.PI) * -1 : max(-1) : min(0);
+};
+
 //=======================================Comb Filters=====================================
 //========================================================================================
 

--- a/filters.lib
+++ b/filters.lib
@@ -157,9 +157,9 @@ dcblocker = zero(1) : pole(0.995);
 // Hal Chamberlin, Musical Applications of Microprocessor, Sams, 1985.
 //-----------------------------------------------------------------------------
 declare lp1p author "Dario Sanfilippo";
-declare lp1p copyright "Copyright (C) 2020 by Dario Sanfilippo 
-      <sanfilippo.dario@gmail.com>"
-declare lp1p license "MIT-style STK-4.3 license"
+declare lp1p copyright "Copyright (C) 2020 by Dario Sanfilippo
+      <sanfilippo.dario@gmail.com>";
+declare lp1p license "MIT-style STK-4.3 license";
 lp1p(cf, x) = x * a0 : pole(b1)
 with {
       a0 = 1 - b1;
@@ -184,8 +184,8 @@ with {
 //-----------------------------------------------------------------------------
 declare hp1p author "Dario Sanfilippo";
 declare hp1p copyright "Copyright (C) 2020 by Dario Sanfilippo 
-      <sanfilippo.dario@gmail.com>"
-declare hp1p license "MIT-style STK-4.3 license"
+      <sanfilippo.dario@gmail.com>";
+declare hp1p license "MIT-style STK-4.3 license";
 hp1p(cf, x) = x * a0 : pole(b1)
 with {
       a0 = 1 + b1;

--- a/oscillators.lib
+++ b/oscillators.lib
@@ -1279,15 +1279,16 @@ polyblep_triangle(f) = polyblep_square(f) : fi.pole(0.999) : *(4 * f / ma.SR);
 // Authors:
 // Dario Sanfilippo <sanfilippo.dario@gmail.com>
 // and Oleg Nesterov (jos ed.)
-quadosc(f) = tick ~ (_,_) : mem+1,mem with {
-  k1 = tan(f * ma.PI/ma.SR);
-  k2 = 2*k1 / (1 + k1 * k1);
-
-  tick(u_0,v_0) = u_1,v_1 with {
-    tmp = u_0 - k1 * v_0;
-    v_1 = v_0 + k2 * (tmp + 1);
-    u_1 = tmp - k1 * v_1;
-  };
+quadosc(f) = tick ~ (_ , _) 
+with {
+      k1 = tan(f * ma.PI / ma.SR);
+      k2 = 2 * k1 / (1 + k1 * k1);
+      tick(u_0, v_0) = u_1 , v_1 
+      with {
+       tmp = u_0 - k1 * v_0;
+       v_1 = v_0 + k2 * tmp;
+       u_1 = tmp - k1 * v_1 : select2(1', 1);
+      };
 };
 
 // end further contributions section


### PR DESCRIPTION
If I'm not wrong, the 1pole LP and HP filters were missing in the libraries.

I find the 1pole LP useful to average quantities at a certain rate, for example, to calculate the RMS or the zero-crossing rate of a signal.