### PR TITLE
added basic lookahead limiter

### DIFF
--- a/compressors.lib
+++ b/compressors.lib
@@ -705,55 +705,6 @@ limiter_1176_R4_mono = compressor_mono(4,-6,0.0008,0.5);
 // TODO: author JOS, revised by RM
 limiter_1176_R4_stereo = compressor_stereo(4,-6,0.0008,0.5);
 
-//-----------------------`(co.)limiter_basic_mono`-----------------------------
-// Simple lookahead limiter based on IOhannes Zmölnig post, which is in
-// turn based on the thesis by Peter Falkner "Entwicklung eines digitalen 
-// Stereo-Limiters mit Hilfe des Signalprozessors DSP56001".
-// This version of the limiter simply uses a peak-holder with smoothed
-// attack and release based on tau time constant filters.
-//
-// It is also possible to use a time constant that is 2*PI*tau by dividing 
-// the attack and release times by 2*PI. This time constant allows for 
-// the amplitude profile to reach 1 - e^(-2pi) of the final 
-// peak after the attack time. The input path can be delayed by the same 
-// amount as the attack time to synchronise input and amplitude profile, 
-// or by any other lookahead time specified by the user.
-//
-// #### Usage
-//
-// ```
-// _ : limiter_basic_mono(lag, threshold, attack, hold, release) : _;
-// ```
-//
-// Where:
-//
-// * `lag` lookahead delay in seconds, known at compile-time.
-// * `threshold` is the linear amplitude limiting threshold:
-//         attenuation if above the threshold, delay-only if below.
-// * `attack` is the attack time in seconds.
-// * `hold` is the hold time in seconds.
-// * `release` is the release time in seconds.
-//
-// Example: limiter_basic_mono(.01, 1, .01, .1, 1);
-//
-// #### Reference:
-//
-// http://iem.at/~zmoelnig/publications/limiter/.
-//-----------------------------------------------------------------------------
-declare limiter_basic_mono author "Dario Sanfilippo";
-declare limiter_basic_mono copyright "Copyright (C) 2020 Dario Sanfilippo 
-      <sanfilippo.dario@gmail.com>";
-declare limiter_basic_mono license "GPLv3 license";
-limiter_basic_mono(lag, threshold, attack, hold, release, x) = 
-      x@(lag * ma.SR) * scaling
-with {
-      scaling = threshold / amp_profile : min(1);
-      amp_profile = ba.peakholder(hold * ma.SR, x) : att_smooth(attack) : 
-           rel_smooth(release);
-      att_smooth(time, in) = si.smooth(ba.tau2pole(time), in);
-      rel_smooth(time, in) = an.peak_envelope(time, in);
-};
-
 //-----------------------`(co.)limiter_basic_N`--------------------------------
 // Simple N-channel lookahead limiter based on IOhannes Zmölnig post, which is 
 // in turn based on the thesis by Peter Falkner "Entwicklung eines digitalen
@@ -774,13 +725,13 @@ with {
 // #### Usage
 //
 // ```
-// si.bus(N) : limiter_basic_N(N, lag, threshold, attack, hold, release) : si.bus(N);
+// si.bus(N) : limiter_basic_N(N, LD, threshold, attack, hold, release) : si.bus(N);
 // ```
 //
 // Where:
 //
 // * `N` is the number of channels, known at compile-time.
-// * `lag` is the lookahead delay in seconds, known at compile-time.
+// * `LD` is the lookahead delay in seconds, known at compile-time.
 // * `threshold` is the linear amplitude limiting threshold.
 // * `attack` is the attack time in seconds.
 // * `hold` is the hold time in seconds.
@@ -792,16 +743,15 @@ with {
 //
 // http://iem.at/~zmoelnig/publications/limiter/.
 //-----------------------------------------------------------------------------
-
 declare limiter_basic_N author "Dario Sanfilippo";
 declare limiter_basic_N copyright "Copyright (C) 2020 Dario Sanfilippo
       <sanfilippo.dario@gmail.com>";
 declare limiter_basic_N license "GPLv3 license";
-limiter_basic_N(N, lag, threshold, attack, hold, release) = 
-      si.bus(N) <: par(i, N, @ (lag * ma.SR)) , 
+limiter_basic_N(N, LD, threshold, attack, hold, release) = 
+      si.bus(N) <: par(i, N, @ (LD * ma.SR)) , 
                    (scaling <: si.bus(N)) : ro.interleave(N, 2) : par(i, N, *)
       with {
-           scaling = threshold , amp_profile : / : min(1);
+           scaling = threshold / max(amp_profile, ma.EPSILON) : min(1);
            amp_profile = par(i, N, abs) : maxN(N) : ba.peakholder(hold * ma.SR) :
                att_smooth(attack) : rel_smooth(release);
            att_smooth(time, in) = si.smooth(ba.tau2pole(time), in);
@@ -809,4 +759,17 @@ limiter_basic_N(N, lag, threshold, attack, hold, release) =
            maxN(1) = _;
            maxN(2) = max;
            maxN(N) = max(maxN(N - 1));
+      };
+// Specialised cases of limiter_basic_N.
+limiter_basic_mono(LD) =
+      limiter_basic_N(1, LD);
+limiter_basic_stereo(LD) =
+      limiter_basic_N(2, LD);
+limiter_basic_quad(LD) =
+      limiter_basic_N(4, LD);
+// Ready-to-use unit-amplitude mono limiting function.
+limiter_lookahead = 
+      limiter_basic_mono(.01, 1, .01 / twopi, .1, 1 / twopi)
+      with {
+           twopi = 2 * ma.PI;
       };

--- a/compressors.lib
+++ b/compressors.lib
@@ -776,7 +776,7 @@ with {
 // #### Usage 
 //
 // ```
-// _ : limiter_Z_mono(LT, LS, AT, RT) : _;
+// _ : limiter_Z_mono(LT, LS, t_a, t_r) : _;
 // ```
 //
 // Where:

--- a/compressors.lib
+++ b/compressors.lib
@@ -710,7 +710,11 @@ limiter_1176_R4_stereo = compressor_stereo(4,-6,0.0008,0.5);
 // turn based on the thesis by Peter Falkner "Entwicklung eines digitalen 
 // Stereo-Limiters mit Hilfe des Signalprozessors DSP56001".
 // This version of the limiter simply uses a peak-holder with smoothed
-// attack and release based on e^(-2pi) time constant filters. 
+// attack and release based on e^(-2pi) time constant filters.
+// This time constant allows for the amplitude profile to reach 1 -
+// e^(-2pi) of the final peak after the attack time. Hence, input path
+// is delayed by the same amount as attack time to synchronise input and
+// amplitude profile.
 //
 // #### Usage
 //
@@ -745,3 +749,23 @@ with {
       att_smooth(time, in) = si.smooth(ba.tau2pole(time / (2 * ma.PI)), in);
       rel_smooth(time, in) = an.peak_envelope(time / (2 * ma.PI), in);
 };
+
+//-----------------------`(co.)limiter_basic_stereo`---------------------------
+// Stereo version of the limiter above where the scaling factor for L
+// and R channels is determined by the loudest peak between the two.
+declare limiter_basic_stereo author "Dario Sanfilippo";
+declare limiter_basic_stereo copyright "Copyright (C) 2020 Dario Sanfilippo
+      <sanfilippo.dario@gmail.com>";
+declare limiter_basic_stereo license "GPLv3 license";
+limiter_basic_stereo(threshold, attack, hold, release, x1, x2) =
+      x1@(attack * ma.SR) * scaling ,
+      x2@(attack * ma.SR) * scaling
+with {
+      peakLR = max(abs(x1), abs(x2));
+      scaling = threshold / amp_profile : min(1);
+      amp_profile = ba.peakholder(hold * ma.SR, peakLR) : att_smooth(attack) :
+       rel_smooth(release);
+      att_smooth(time, in) = si.smooth(ba.tau2pole(time / (2 * ma.PI)), in);
+      rel_smooth(time, in) = an.peak_envelope(time / (2 * ma.PI), in);
+};
+

--- a/compressors.lib
+++ b/compressors.lib
@@ -774,7 +774,7 @@ with {
 // #### Usage
 //
 // ```
-// si.bus(N) : limiter_basic_stereo(N, lag, threshold, attack, hold, release) : si.bus(N);
+// si.bus(N) : limiter_basic_N(N, lag, threshold, attack, hold, release) : si.bus(N);
 // ```
 //
 // Where:
@@ -786,7 +786,7 @@ with {
 // * `hold` is the hold time in seconds.
 // * `release` is the release time in seconds.
 //
-// Example for a stereo limiter: limiter_basic_mono(2, .01, 1, .01, .1, 1);
+// Example for a stereo limiter: limiter_basic_N(2, .01, 1, .01, .1, 1);
 //
 // #### Reference:
 //

--- a/compressors.lib
+++ b/compressors.lib
@@ -704,3 +704,44 @@ limiter_1176_R4_mono = compressor_mono(4,-6,0.0008,0.5);
 //------------------------------------------------------------
 // TODO: author JOS, revised by RM
 limiter_1176_R4_stereo = compressor_stereo(4,-6,0.0008,0.5);
+
+//-----------------------`(co.)limiter_basic_mono`-----------------------------
+// Simple lookahead limiter based on IOhannes Zmölnig post, which is in
+// turn based on the thesis by Peter Falkner "Entwicklung eines digitalen 
+// Stereo-Limiters mit Hilfe des Signalprozessors DSP56001".
+// This version of the limiter simply uses a peak-holder with smoothed
+// attack and release based on e^(-2pi) time constant filters. 
+//
+// #### Usage
+//
+// ```
+// _ : limiter_basic_mono(threshold, attack, hold, release) : _;
+// ```
+//
+// Where:
+//
+// * `threshold` is the linear amplitude limiting threshold.
+// * `attack` is the attack time in seconds 
+//     (note that it sets the input delay and it must be known at compile-time).
+// * `hold` is hold time in seconds.
+// * `release` is release time in seconds.
+//
+// Example: limiter_basic_mono(1, .01, .1, 1);
+//
+// #### Reference:
+//
+// http://iem.at/~zmoelnig/publications/limiter/
+//-----------------------------------------------------------------------------
+declare limiter_basic_mono author "Dario Sanfilippo";
+declare limiter_basic_mono copyright "Copyright (C) 2020 Dario Sanfilippo 
+      <sanfilippo.dario@gmail.com>";
+declare limiter_basic_mono license "GPLv3 license";
+limiter_basic_mono(threshold, attack, hold, release, x) = 
+      x@(attack * ma.SR) * scaling
+with {
+      scaling = threshold / amp_profile : min(1);
+      amp_profile = ba.peakholder(hold * ma.SR, x) : att_smooth(attack) : 
+       rel_smooth(release);
+      att_smooth(time, in) = si.smooth(ba.tau2pole(time / (2 * ma.PI)), in);
+      rel_smooth(time, in) = an.peak_envelope(time / (2 * ma.PI), in);
+};

--- a/compressors.lib
+++ b/compressors.lib
@@ -712,25 +712,26 @@ limiter_1176_R4_stereo = compressor_stereo(4,-6,0.0008,0.5);
 // This version of the limiter simply uses a peak-holder with smoothed
 // attack and release based on e^(-2pi) time constant filters.
 // This time constant allows for the amplitude profile to reach 1 -
-// e^(-2pi) of the final peak after the attack time. Hence, input path
-// is delayed by the same amount as attack time to synchronise input and
-// amplitude profile.
+// e^(-2pi) of the final peak after the attack time. The input path
+// can be delayed by the same amount as attack time to synchronise input and
+// amplitude profile, or by any other lookahead time specified by the user.
 //
 // #### Usage
 //
 // ```
-// _ : limiter_basic_mono(threshold, attack, hold, release) : _;
+// _ : limiter_basic_mono(threshold, lag, attack, hold, release) : _;
 // ```
 //
 // Where:
 //
 // * `threshold` is the linear amplitude limiting threshold.
+// * `lag` lookahead delay in seconds.
 // * `attack` is the attack time in seconds 
 //     (note that it sets the input delay and it must be known at compile-time).
 // * `hold` is hold time in seconds.
 // * `release` is release time in seconds.
 //
-// Example: limiter_basic_mono(1, .01, .1, 1);
+// Example: limiter_basic_mono(1, .01, .01, .1, 1);
 //
 // #### Reference:
 //
@@ -740,8 +741,8 @@ declare limiter_basic_mono author "Dario Sanfilippo";
 declare limiter_basic_mono copyright "Copyright (C) 2020 Dario Sanfilippo 
       <sanfilippo.dario@gmail.com>";
 declare limiter_basic_mono license "GPLv3 license";
-limiter_basic_mono(threshold, attack, hold, release, x) = 
-      x@(attack * ma.SR) * scaling
+limiter_basic_mono(threshold, lag, attack, hold, release, x) = 
+      x@(lag * ma.SR) * scaling
 with {
       scaling = threshold / amp_profile : min(1);
       amp_profile = ba.peakholder(hold * ma.SR, x) : att_smooth(attack) : 
@@ -751,15 +752,48 @@ with {
 };
 
 //-----------------------`(co.)limiter_basic_stereo`---------------------------
-// Stereo version of the limiter above where the scaling factor for L
-// and R channels is determined by the loudest peak between the two.
+// Simple stereo lookahead limiter based on IOhannes Zmölnig post, which is in
+// turn based on the thesis by Peter Falkner "Entwicklung eines digitalen
+// Stereo-Limiters mit Hilfe des Signalprozessors DSP56001".
+// This version of the limiter simply uses a peak-holder with smoothed
+// attack and release based on e^(-2pi) time constant filters.
+// This time constant allows for the amplitude profile to reach 1 -
+// e^(-2pi) of the final peak after the attack time. The input path
+// can be delayed by the same amount as attack time to synchronise input and
+// amplitude profile, or by any other lookahead time specified by the user.
+// The scaling factor for L and R channels is determined by the loudest peak 
+// between the two.
+
+//
+// #### Usage
+//
+// ```
+// _ , _ : limiter_basic_stereo(threshold, lag, attack, hold, release) : _ , _;
+// ```
+//
+// Where:
+//
+// * `threshold` is the linear amplitude limiting threshold.
+// * `lag` lookahead delay in seconds.
+// * `attack` is the attack time in seconds
+//     (note that it sets the input delay and it must be known at compile-time).
+// * `hold` is hold time in seconds.
+// * `release` is release time in seconds.
+//
+// Example: limiter_basic_mono(1, .01, .01, .1, 1);
+//
+// #### Reference:
+//
+// http://iem.at/~zmoelnig/publications/limiter/.
+//-----------------------------------------------------------------------------
+
 declare limiter_basic_stereo author "Dario Sanfilippo";
 declare limiter_basic_stereo copyright "Copyright (C) 2020 Dario Sanfilippo
       <sanfilippo.dario@gmail.com>";
 declare limiter_basic_stereo license "GPLv3 license";
 limiter_basic_stereo(threshold, attack, hold, release, x1, x2) =
-      x1@(attack * ma.SR) * scaling ,
-      x2@(attack * ma.SR) * scaling
+      x1@(lag * ma.SR) * scaling ,
+      x2@(lag * ma.SR) * scaling
 with {
       peakLR = max(abs(x1), abs(x2));
       scaling = threshold / amp_profile : min(1);
@@ -767,61 +801,4 @@ with {
        rel_smooth(release);
       att_smooth(time, in) = si.smooth(ba.tau2pole(time / (2 * ma.PI)), in);
       rel_smooth(time, in) = an.peak_envelope(time / (2 * ma.PI), in);
-};
-
-//------------------------`limiter_Z_mono`-----------------------------------
-// Mono limiter implementation of the algorithm found in [Zölzer 2008].
-// Inputs are: limiter threshold, limiter slope, attack, release (in ms).
-//
-// #### Usage 
-//
-// ```
-// _ : limiter_Z_mono(LT, LS, t_a, t_r) : _;
-// ```
-//
-// Where:
-//
-// * `LT` is the limiting threshold.
-// * `LS` is the limiting slope.
-// * `t_a` is the attack time (ms).
-// * `t_r` is the release time (ms).
-//
-// #### Reference:
-//
-// Zölzer, U., 2008. Digital audio signal processing (Vol. 9). New York: Wiley.
-//-----------------------------------------------------------------------------
-declare limiter_Z_mono author "Dario Sanfilippo";
-declare limiter_Z_mono copyright "Copyright (C) 2020 Dario Sanfilippo
-      <sanfilippo.dario@gmail.com>";
-declare limiter_Z_mono license "GPLv3 license";
-limiter_Z_mono(LT, LS, t_a, t_r, x) =
-      x@(t_a / 1000 * ma.SR) * g
-with {
-      T_s = 1 / ma.SR;
-      AT = 1 - exp((-2.2 * T_s) / (t_a / 1000));
-      RT = 1 - exp((-2.2 * T_s) / (t_r / 1000));
-      g = ba.if(logpeakLT > 0, logpeakLT * -LS, 1) : pow(2, _) : smooth;
-      smooth(in) = coeff * in :    +
-                                   ~ * (1 - coeff)
-      with {
-       coeff = ba.if(hysteresis(in' - in), AT, RT);
-      };
-      hysteresis(in1) =    loop 
-                           ~ _
-      with {
-       loop(fb) = ba.if(in1 <= alpha, 0, ba.if(in1 >= beta, 1, fb));
-       alpha = -1 / (t_r / 1000) / ma.SR;
-       beta = 1 / (t_a / 1000) / ma.SR;
-      };
-      logpeakLT = ma.log2(peak_a_r) - LT;
-      peak_a_r =   loop
-                   ~ _
-      with {
-       loop(fb) = ba.if(abs(x) > fb, attack(x), release(fb))
-       with {
-           attack = AT * abs : +
-                               ~ * (1 - AT);
-           release = * (1 - RT);
-       };
-      };
 };

--- a/compressors.lib
+++ b/compressors.lib
@@ -710,28 +710,31 @@ limiter_1176_R4_stereo = compressor_stereo(4,-6,0.0008,0.5);
 // turn based on the thesis by Peter Falkner "Entwicklung eines digitalen 
 // Stereo-Limiters mit Hilfe des Signalprozessors DSP56001".
 // This version of the limiter simply uses a peak-holder with smoothed
-// attack and release based on e^(-2pi) time constant filters.
-// This time constant allows for the amplitude profile to reach 1 -
-// e^(-2pi) of the final peak after the attack time. The input path
-// can be delayed by the same amount as attack time to synchronise input and
-// amplitude profile, or by any other lookahead time specified by the user.
+// attack and release based on tau time constant filters.
+//
+// It is also possible to use a time constant that is 2*PI*tau by dividing 
+// the attack and release times by 2*PI. This time constant allows for 
+// the amplitude profile to reach 1 - e^(-2pi) of the final 
+// peak after the attack time. The input path can be delayed by the same 
+// amount as the attack time to synchronise input and amplitude profile, 
+// or by any other lookahead time specified by the user.
 //
 // #### Usage
 //
 // ```
-// _ : limiter_basic_mono(threshold, lag, attack, hold, release) : _;
+// _ : limiter_basic_mono(lag, threshold, attack, hold, release) : _;
 // ```
 //
 // Where:
 //
-// * `threshold` is the linear amplitude limiting threshold.
-// * `lag` lookahead delay in seconds.
-// * `attack` is the attack time in seconds 
-//     (note that it sets the input delay and it must be known at compile-time).
-// * `hold` is hold time in seconds.
-// * `release` is release time in seconds.
+// * `lag` lookahead delay in seconds, known at compile-time.
+// * `threshold` is the linear amplitude limiting threshold:
+//         attenuation if above the threshold, delay-only if below.
+// * `attack` is the attack time in seconds.
+// * `hold` is the hold time in seconds.
+// * `release` is the release time in seconds.
 //
-// Example: limiter_basic_mono(1, .01, .01, .1, 1);
+// Example: limiter_basic_mono(.01, 1, .01, .1, 1);
 //
 // #### Reference:
 //
@@ -741,64 +744,69 @@ declare limiter_basic_mono author "Dario Sanfilippo";
 declare limiter_basic_mono copyright "Copyright (C) 2020 Dario Sanfilippo 
       <sanfilippo.dario@gmail.com>";
 declare limiter_basic_mono license "GPLv3 license";
-limiter_basic_mono(threshold, lag, attack, hold, release, x) = 
+limiter_basic_mono(lag, threshold, attack, hold, release, x) = 
       x@(lag * ma.SR) * scaling
 with {
       scaling = threshold / amp_profile : min(1);
       amp_profile = ba.peakholder(hold * ma.SR, x) : att_smooth(attack) : 
-       rel_smooth(release);
-      att_smooth(time, in) = si.smooth(ba.tau2pole(time / (2 * ma.PI)), in);
-      rel_smooth(time, in) = an.peak_envelope(time / (2 * ma.PI), in);
+           rel_smooth(release);
+      att_smooth(time, in) = si.smooth(ba.tau2pole(time), in);
+      rel_smooth(time, in) = an.peak_envelope(time, in);
 };
 
-//-----------------------`(co.)limiter_basic_stereo`---------------------------
-// Simple stereo lookahead limiter based on IOhannes Zmölnig post, which is in
-// turn based on the thesis by Peter Falkner "Entwicklung eines digitalen
+//-----------------------`(co.)limiter_basic_N`--------------------------------
+// Simple N-channel lookahead limiter based on IOhannes Zmölnig post, which is 
+// in turn based on the thesis by Peter Falkner "Entwicklung eines digitalen
 // Stereo-Limiters mit Hilfe des Signalprozessors DSP56001".
 // This version of the limiter simply uses a peak-holder with smoothed
-// attack and release based on e^(-2pi) time constant filters.
-// This time constant allows for the amplitude profile to reach 1 -
-// e^(-2pi) of the final peak after the attack time. The input path
-// can be delayed by the same amount as attack time to synchronise input and
-// amplitude profile, or by any other lookahead time specified by the user.
-// The scaling factor for L and R channels is determined by the loudest peak 
-// between the two.
-
+// attack and release based on tau time constant filters.
+//
+// It is also possible to use a time constant that is 2*PI*tau by dividing 
+// the attack and release times by 2*PI. This time constant allows for 
+// the amplitude profile to reach 1 - e^(-2pi) of the final 
+// peak after the attack time. The input path can be delayed by the same 
+// amount as the attack time to synchronise input and amplitude profile, 
+// or by any other lookahead time specified by the user.
+//
+// The scaling factor for all the channels is determined by the loudest peak 
+// between them all, so that amplitude ratios between the signals are kept.
 //
 // #### Usage
 //
 // ```
-// _ , _ : limiter_basic_stereo(threshold, lag, attack, hold, release) : _ , _;
+// si.bus(N) : limiter_basic_stereo(N, lag, threshold, attack, hold, release) : si.bus(N);
 // ```
 //
 // Where:
 //
+// * `N` is the number of channels, known at compile-time.
+// * `lag` is the lookahead delay in seconds, known at compile-time.
 // * `threshold` is the linear amplitude limiting threshold.
-// * `lag` lookahead delay in seconds.
-// * `attack` is the attack time in seconds
-//     (note that it sets the input delay and it must be known at compile-time).
-// * `hold` is hold time in seconds.
-// * `release` is release time in seconds.
+// * `attack` is the attack time in seconds.
+// * `hold` is the hold time in seconds.
+// * `release` is the release time in seconds.
 //
-// Example: limiter_basic_mono(1, .01, .01, .1, 1);
+// Example for a stereo limiter: limiter_basic_mono(2, .01, 1, .01, .1, 1);
 //
 // #### Reference:
 //
 // http://iem.at/~zmoelnig/publications/limiter/.
 //-----------------------------------------------------------------------------
 
-declare limiter_basic_stereo author "Dario Sanfilippo";
-declare limiter_basic_stereo copyright "Copyright (C) 2020 Dario Sanfilippo
+declare limiter_basic_N author "Dario Sanfilippo";
+declare limiter_basic_N copyright "Copyright (C) 2020 Dario Sanfilippo
       <sanfilippo.dario@gmail.com>";
-declare limiter_basic_stereo license "GPLv3 license";
-limiter_basic_stereo(threshold, lag, attack, hold, release, x1, x2) =
-      x1@(lag * ma.SR) * scaling ,
-      x2@(lag * ma.SR) * scaling
-with {
-      peakLR = max(abs(x1), abs(x2));
-      scaling = threshold / amp_profile : min(1);
-      amp_profile = ba.peakholder(hold * ma.SR, peakLR) : att_smooth(attack) :
-       rel_smooth(release);
-      att_smooth(time, in) = si.smooth(ba.tau2pole(time / (2 * ma.PI)), in);
-      rel_smooth(time, in) = an.peak_envelope(time / (2 * ma.PI), in);
-};
+declare limiter_basic_N license "GPLv3 license";
+limiter_basic_N(N, lag, threshold, attack, hold, release) = 
+      si.bus(N) <: par(i, N, @ (lag * ma.SR)) , 
+                   (scaling <: si.bus(N)) : ro.interleave(N, 2) : par(i, N, *)
+      with {
+           scaling = threshold , amp_profile : / : min(1);
+           amp_profile = par(i, N, abs) : maxN(N) : ba.peakholder(hold * ma.SR) :
+               att_smooth(attack) : rel_smooth(release);
+           att_smooth(time, in) = si.smooth(ba.tau2pole(time), in);
+           rel_smooth(time, in) = an.peak_envelope(time, in);
+           maxN(1) = _;
+           maxN(2) = max;
+           maxN(N) = max(maxN(N - 1));
+      };

--- a/compressors.lib
+++ b/compressors.lib
@@ -800,7 +800,7 @@ with {
       T_s = 1 / ma.SR;
       AT = 1 - exp((-2.2 * T_s) / (t_a / 1000));
       RT = 1 - exp((-2.2 * T_s) / (t_r / 1000));
-      g = ba.if(logpeakLT > LT, logpeakLT * -LS, 1) : pow(2, _) : smooth;
+      g = ba.if(logpeakLT > 0, logpeakLT * -LS, 1) : pow(2, _) : smooth;
       smooth(in) = coeff * in :    +
                                    ~ * (1 - coeff)
       with {

--- a/compressors.lib
+++ b/compressors.lib
@@ -769,3 +769,41 @@ with {
       rel_smooth(time, in) = an.peak_envelope(time / (2 * ma.PI), in);
 };
 
+//------------------------`limiter_Z_mono`-----------------------------------
+// Mono limiter implementation of the algorithm found in [Zolzer 2008]
+// Inputs are: limiter threshold, limiter slope, attack and release in ms.
+declare limiter_Z_mono author "Dario Sanfilippo";
+declare limiter_Z_mono copyright "Copyright (C) 2020 Dario Sanfilippo
+      <sanfilippo.dario@gmail.com>";
+declare limiter_Z_mono license "GPLv3 license";
+limiter_Z_mono(LT, LS, t_a, t_r, x) =
+      x@(t_a / 1000 * ma.SR) * g
+with {
+      T_s = 1 / ma.SR;
+      AT = 1 - exp((-2.2 * T_s) / (t_a / 1000));
+      RT = 1 - exp((-2.2 * T_s) / (t_r / 1000));
+      g = ba.if(logpeakLT > LT, logpeakLT * -LS, 1) : pow(2, _) : smooth;
+      smooth(in) = coeff * in :    +
+                                   ~ * (1 - coeff)
+      with {
+       coeff = ba.if(hysteresis(in' - in), AT, RT);
+      };
+      hysteresis(in1) =    loop 
+                           ~ _
+      with {
+       loop(fb) = ba.if(in1 <= alpha, 0, ba.if(in1 >= beta, 1, fb));
+       alpha = -1 / (t_r / 1000) / ma.SR;
+       beta = 1 / (t_a / 1000) / ma.SR;
+      };
+      logpeakLT = ma.log2(peak_a_r) - LT;
+      peak_a_r =   loop
+                   ~ _
+      with {
+       loop(fb) = ba.if(abs(x) > fb, attack(x), release(fb))
+       with {
+           attack = AT * abs : +
+                               ~ * (1 - AT);
+           release = * (1 - RT);
+       };
+      };
+};

--- a/compressors.lib
+++ b/compressors.lib
@@ -791,7 +791,7 @@ declare limiter_basic_stereo author "Dario Sanfilippo";
 declare limiter_basic_stereo copyright "Copyright (C) 2020 Dario Sanfilippo
       <sanfilippo.dario@gmail.com>";
 declare limiter_basic_stereo license "GPLv3 license";
-limiter_basic_stereo(threshold, attack, hold, release, x1, x2) =
+limiter_basic_stereo(threshold, lag, attack, hold, release, x1, x2) =
       x1@(lag * ma.SR) * scaling ,
       x2@(lag * ma.SR) * scaling
 with {

--- a/compressors.lib
+++ b/compressors.lib
@@ -734,7 +734,7 @@ limiter_1176_R4_stereo = compressor_stereo(4,-6,0.0008,0.5);
 //
 // #### Reference:
 //
-// http://iem.at/~zmoelnig/publications/limiter/
+// http://iem.at/~zmoelnig/publications/limiter/.
 //-----------------------------------------------------------------------------
 declare limiter_basic_mono author "Dario Sanfilippo";
 declare limiter_basic_mono copyright "Copyright (C) 2020 Dario Sanfilippo 
@@ -770,8 +770,26 @@ with {
 };
 
 //------------------------`limiter_Z_mono`-----------------------------------
-// Mono limiter implementation of the algorithm found in [Zolzer 2008]
-// Inputs are: limiter threshold, limiter slope, attack and release in ms.
+// Mono limiter implementation of the algorithm found in [Zölzer 2008].
+// Inputs are: limiter threshold, limiter slope, attack, release (in ms).
+//
+// #### Usage 
+//
+// ```
+// _ : limiter_Z_mono(LT, LS, AT, RT) : _;
+// ```
+//
+// Where:
+//
+// * `LT` is the limiting threshold.
+// * `LS` is the limiting slope.
+// * `t_a` is the attack time (ms).
+// * `t_r` is the release time (ms).
+//
+// #### Reference:
+//
+// Zölzer, U., 2008. Digital audio signal processing (Vol. 9). New York: Wiley.
+//-----------------------------------------------------------------------------
 declare limiter_Z_mono author "Dario Sanfilippo";
 declare limiter_Z_mono copyright "Copyright (C) 2020 Dario Sanfilippo
       <sanfilippo.dario@gmail.com>";

--- a/compressors.lib
+++ b/compressors.lib
@@ -705,7 +705,7 @@ limiter_1176_R4_mono = compressor_mono(4,-6,0.0008,0.5);
 // TODO: author JOS, revised by RM
 limiter_1176_R4_stereo = compressor_stereo(4,-6,0.0008,0.5);
 
-//-----------------------`(co.)limiter_basic_N`--------------------------------
+//-----------------------`(co.)limiter_basic_N`---------------------------------
 // Simple N-channel lookahead limiter based on IOhannes Zmölnig post, which is 
 // in turn based on the thesis by Peter Falkner "Entwicklung eines digitalen
 // Stereo-Limiters mit Hilfe des Signalprozessors DSP56001".
@@ -725,7 +725,8 @@ limiter_1176_R4_stereo = compressor_stereo(4,-6,0.0008,0.5);
 // #### Usage
 //
 // ```
-// si.bus(N) : limiter_basic_N(N, LD, threshold, attack, hold, release) : si.bus(N);
+// si.bus(N) : limiter_basic_N(N, LD, threshold, attack, hold, release) : 
+//    si.bus(N);
 // ```
 //
 // Where:
@@ -742,7 +743,7 @@ limiter_1176_R4_stereo = compressor_stereo(4,-6,0.0008,0.5);
 // #### Reference:
 //
 // http://iem.at/~zmoelnig/publications/limiter/.
-//-----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 declare limiter_basic_N author "Dario Sanfilippo";
 declare limiter_basic_N copyright "Copyright (C) 2020 Dario Sanfilippo
       <sanfilippo.dario@gmail.com>";
@@ -760,16 +761,109 @@ limiter_basic_N(N, LD, threshold, attack, hold, release) =
            maxN(2) = max;
            maxN(N) = max(maxN(N - 1));
       };
-// Specialised cases of limiter_basic_N.
-limiter_basic_mono(LD) =
-      limiter_basic_N(1, LD);
-limiter_basic_stereo(LD) =
-      limiter_basic_N(2, LD);
-limiter_basic_quad(LD) =
-      limiter_basic_N(4, LD);
-// Ready-to-use unit-amplitude mono limiting function.
-limiter_lookahead = 
-      limiter_basic_mono(.01, 1, .01 / twopi, .1, 1 / twopi)
+
+//-------------`(co.)limiter_basic_mono`----------------------------------------
+//
+// Specialised case of limiter_basic_N: mono limiter.
+//
+// #### Usage
+//
+// ```
+// _ : limiter_basic_mono(LD, threshold, attack, hold, release) : _;
+// ```
+//
+// Where:
+//
+// * `LD` is the lookahead delay in seconds, known at compile-time.
+// * `threshold` is the linear amplitude limiting threshold.
+// * `attack` is the attack time in seconds.
+// * `hold` is the hold time in seconds.
+// * `release` is the release time in seconds.
+//
+// #### Reference:
+//
+// http://iem.at/~zmoelnig/publications/limiter/.
+declare limiter_basic_mono author "Dario Sanfilippo";
+declare limiter_basic_mono copyright "Copyright (C) 2020 Dario Sanfilippo
+      <sanfilippo.dario@gmail.com>";
+declare limiter_basic_mono license "GPLv3 license";
+limiter_basic_mono(LD) = limiter_basic_N(1, LD);
+
+//-------------`(co.)limiter_basic_stereo`--------------------------------------
+//
+// Specialised case of limiter_basic_N: stereo limiter.
+//
+// #### Usage
+//
+// ```
+// _ , _ : limiter_basic_stereo(LD, threshold, attack, hold, release) : _ , _;
+// ```
+//
+// Where:
+//
+// * `LD` is the lookahead delay in seconds, known at compile-time.
+// * `threshold` is the linear amplitude limiting threshold.
+// * `attack` is the attack time in seconds.
+// * `hold` is the hold time in seconds.
+// * `release` is the release time in seconds.
+//
+// #### Reference:
+//
+// http://iem.at/~zmoelnig/publications/limiter/.
+declare limiter_basic_stereo author "Dario Sanfilippo";
+declare limiter_basic_stereo copyright "Copyright (C) 2020 Dario Sanfilippo
+      <sanfilippo.dario@gmail.com>";
+declare limiter_basic_stereo license "GPLv3 license";
+limiter_basic_stereo(LD) = limiter_basic_N(2, LD);
+
+//-------------`(co.)limiter_basic_quad`----------------------------------------
+//
+// Specialised case of limiter_basic_N: quadraphonic limiter.
+//
+// #### Usage
+//
+// ```
+// si.bus(4) : limiter_basic_quad(LD, threshold, attack, hold, release) : 
+//    si.bus(4);
+// ```
+//
+// Where:
+//
+// * `LD` is the lookahead delay in seconds, known at compile-time.
+// * `threshold` is the linear amplitude limiting threshold.
+// * `attack` is the attack time in seconds.
+// * `hold` is the hold time in seconds.
+// * `release` is the release time in seconds.
+//
+// #### Reference:
+//
+// http://iem.at/~zmoelnig/publications/limiter/.
+declare limiter_basic_quad author "Dario Sanfilippo";
+declare limiter_basic_quad copyright "Copyright (C) 2020 Dario Sanfilippo
+      <sanfilippo.dario@gmail.com>";
+declare limiter_basic_quad license "GPLv3 license";
+limiter_basic_quad(LD) = limiter_basic_N(4, LD);
+
+//-------------`(co.)limiter_lookahead`-----------------------------------------
+//
+// Specialised case of limiter_basic_N and ready-to-use unit-amplitude mono 
+// limiting function. This implementation, in particular, uses 2pi*tau
+// time constant filters for attack and release smoothing.
+//
+// #### Usage
+//
+// ```
+// _ : limiter_lookahead : _;
+// ```
+//
+// #### Reference:
+//
+// http://iem.at/~zmoelnig/publications/limiter/.
+declare limiter_lookahead author "Dario Sanfilippo";
+declare limiter_lookahead copyright "Copyright (C) 2020 Dario Sanfilippo
+      <sanfilippo.dario@gmail.com>";
+declare limiter_lookahead license "GPLv3 license";
+limiter_lookahead = limiter_basic_mono(.01, 1, .01 / twopi, .1, 1 / twopi)
       with {
            twopi = 2 * ma.PI;
       };


### PR DESCRIPTION
Basic lookahead limiter based on Zmölnig / Falkner.

This function might be particularly useful for those who need a cheap limiter with low distortion, although release times may not be acceptable for all applications.