### PR TITLE
fix ho.rotate function in hoa.lib

### DIFF
--- a/hoa.lib
+++ b/hoa.lib
@@ -278,7 +278,7 @@ with {
 		indexabs = (int)((i - 1) / 2 + 1);
 		gain1(i, j, a) = _ * cos(a * indexabs) * (j == i);
 		gain2(i, j, a) = _ * sin(a * indexabs) * (j-1 == i) * (j != 0) * (i%2 == 1);
-		gain3(i, j, a) = (_ * sin(a * indexabs)) * (j+1 == i) * (j != 0) * (i%2 == 0);
+		gain3(i, j, a) = (_ * sin(a * indexabs)) * (j+1 == i) * (j != 0) * (i%2 == 0) * (-1);
 	};
 };
 


### PR DESCRIPTION
This PR fixes the ho.rotate function because the signal is inverted (+/-).