### PR TITLE
compressors: add missing functions

### DIFF
--- a/basics.lib
+++ b/basics.lib
@@ -1602,6 +1602,102 @@ slidingRMS(n) = pow(2) : slidingMean(n) : sqrt;
 slidingRMSp(n,maxn) = pow(2) : slidingMeanp(n,maxn) : sqrt;
 
 
+
+//========================================================================================
+// section contributed by Bart Brouns (bart@magnetophon.nl).
+// spdx-license-identifier: gpl-3.0
+// copyright (c) 2020 Bart Brouns
+
+//=================================Parallel Operator=========================================
+// Provides various operations on N parallel inputs using a high order
+// `parallelOp(op,N,x)`` function:
+//
+// * `parallelMax(n)`: the max of n parallel inputs
+// * `parallelMin(n)`: the min of n parallel inputs
+// * `parallelMean(n)`: the mean of n parallel inputs
+// * `parallelRMS(n)`: the RMS of n parallel inputs
+
+//-----------------------------`(ba.)parallelOp`-----------------------------
+// Apply a commutative binary operation `<op>` to n parallel inputs.
+//
+// #### usage
+//
+// ```
+// si.bus(n) : parallelOp(op,n) : _
+// ```
+//
+// where:
+//
+// * `n`: the number of parallel inputs
+// * `op`: the operator. needs to be a commutative one.
+//
+//------------------------------------------------------------------------------
+
+parallelOp(op,1) = _;
+parallelOp(op,2) = op;
+parallelOp(op,n) = (parallelOp(n-1),_):op;
+
+//---------------------------`(ba.)parallelMax`---------------------------------
+// The maximum of n parallel inputs
+//
+// #### Usage
+//
+// ```
+// si.bus(n) : parallelMax(n) : _
+// ```
+//
+// Where:
+//
+// * `n`: the number of parallel inputs
+//------------------------------------------------------------------------------
+parallelMax(n) = parallelOp(max,n);
+
+//---------------------------`(ba.)parallelMin`---------------------------------
+// The minimum of n parallel inputs
+//
+// #### Usage
+//
+// ```
+// si.bus(n) : parallelMin(n) : _
+// ```
+//
+// Where:
+//
+// * `n`: the number of parallel inputs
+//------------------------------------------------------------------------------
+parallelMin(n) = parallelOp(min,n);
+
+//---------------------------`(ba.)parallelMean`---------------------------------
+// The mean of n parallel inputs
+//
+// #### Usage
+//
+// ```
+// si.bus(n) : parallelMean(n) : _
+// ```
+//
+// Where:
+//
+// * `n`: the number of parallel inputs
+//------------------------------------------------------------------------------
+parallelMean(n) = si.bus(n):>_/n;
+
+//---------------------------`(ba.)parallelRMS`---------------------------------
+// The RMS of n parallel inputs
+//
+// #### Usage
+//
+// ```
+// si.bus(n) : parallelRMS(n) : _
+// ```
+//
+// Where:
+//
+// * `n`: the number of parallel inputs
+//------------------------------------------------------------------------------
+parallelRMS(n) = par(i, n, pow(2)):parallelMean(n) : sqrt;
+
+
 //////////////////////////////////Deprecated Functions////////////////////////////////////
 // This section implements functions that used to be in music.lib but that are now
 // considered as "deprecated".

--- a/compressors.lib
+++ b/compressors.lib
@@ -39,9 +39,10 @@ si = library("signals.lib");
 an = library("analyzers.lib");
 ro = library("routes.lib");
 ma = library("maths.lib");
+it = library("interpolators.lib");
 
 declare name "Faust Compressor Effect Library";
-declare version "0.0";
+declare version "0.1";
 //=============================Functions Reference========================================
 //========================================================================================
 
@@ -159,7 +160,7 @@ peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,1) =
 // to link/unlink channels
 peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) =
   par(i, N, peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost))
-  <:(si.bus(N),(ba.minimum(N)<:si.bus(N))):ro.interleave(N,2):par(i,N,(ba.crossfade(link)));
+  <:(si.bus(N),(ba.parallelMin(N)<:si.bus(N))):ro.interleave(N,2):par(i,N,(it.interpolate_linear(link)));
 
 
 //--------------------`(co.)FFcompressor_N_chan`-------------------
@@ -323,8 +324,8 @@ FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) =
   si.bus(N) <: si.bus(N*2):
   (
     ((
-      (par(i, 2, peak_compression_gain_N_chan(strength*(1+((i==0)*2)),thresh,att,rel,knee,prePost,link,N)):ro.interleave(N,2):par(i, N, ba.crossfade(FBFF)))
-      ,si.bus(N))
+      (par(i, 2, peak_compression_gain_N_chan(strength*(1+((i==0)*2)),thresh,att,rel,knee,prePost,link,N)):ro.interleave(N,2):par(i, N, it.interpolate_linear(FBFF)))
+     ,si.bus(N))
       :(ro.interleave(N,2):par(i,N,meter*_))
     )~si.bus(N)
   );
@@ -435,7 +436,7 @@ RMS_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,1) =
 
 RMS_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) =
   par(i, N, RMS_compression_gain_mono(strength,thresh,att,rel,knee,prePost))
-  <:(si.bus(N),(ba.minimum(N)<:si.bus(N))):ro.interleave(N,2):par(i,N,(ba.crossfade(link)));
+  <:(si.bus(N),(ba.parallelMin(N)<:si.bus(N))):ro.interleave(N,2):par(i,N,(it.interpolate_linear(link)));
 
 
 //--------------------`(co.)RMS_FFFBcompressor_N_chan`-------------------
@@ -498,8 +499,8 @@ RMS_FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N
   (
     (
       (
-        (ro.interleave(N,2):par(i, N*2, abs) :par(i, N, ba.crossfade(FBFF)) : RMS_compression_gain_N_chan(strength*(1+(((FBFF*-1)+1)*1)),thresh,att,rel,knee,prePost,link,N))
-        ,si.bus(N)
+        (ro.interleave(N,2):par(i, N*2, abs) :par(i, N, it.interpolate_linear(FBFF)) : RMS_compression_gain_N_chan(strength*(1+(((FBFF*-1)+1)*1)),thresh,att,rel,knee,prePost,link,N))
+       ,si.bus(N)
       )
     :(ro.interleave(N,2):par(i,N,meter*_))
     )~si.bus(N)


### PR DESCRIPTION
the compressors where using:
- ba.crossfade, replaced by it.interpolate_linear
- ba.minimum, replaced by ba.parallelMin

Added ba.parallelMin as well as a generalized version and versions with
the other binary commutative operators.
I left out parallelSum, since I figured it was too basic: si.bus(n):>_