### PR TITLE
wdmodels.lib v. 0.2.0

### DIFF
--- a/wdmodels.lib
+++ b/wdmodels.lib
@@ -38,7 +38,7 @@
 // ```
 // vs1(i) = wd.u_voltage(i, no.noise);
 // r1(i) = wd.resistor(i, 47*10^3);
-// c1(i) = wd.capacitor_output(i, 10*10^-9);
+// c1(i) = wd.capacitor_Vout(i, 10*10^-9);
 // ```
 
 // Note that the first argument, i, is left un-parametrized. Components must be declared in this form, as the build algorithm expects to receive adaptors which have exactly one parameter. 
@@ -98,19 +98,12 @@
 
 // Note that the tree and components must be declared inside a `with{...}` statement, or the model's parameters will not be accessible. 
 
-// ##### Depreciated Input Method (Not Recommended)
+// ##### The Empty Signal Operator
 
-// It is also possible to declare inputs using the signal operator, `_`. For example, one might use
+// The Empty signal operator, `_` should NEVER be used to declare a parameter as in input in a wave-digital model. 
 
-// `vin(i) = wd.u_voltage(i, _);`
+// Using it will result on breaking the internal routing of the model and thus breaks the model. Instead, use explicit declaration as shown directly above. 
 
-// in order to simulate an audio input to the circuit.
-
-// However, since build functions do not have access to individual component parameter details, the task of declaring inputs using this method can quickly become complex and **is not recommended**. 
-
-// Only the root and bottom-most / left-most leaf element can accept a parameter input this way. 
-
-// Additionally, manual routing must be performed within the feedforward term as the function input/output mismatch will cause errors in the model. 
 
 
 // ### Trees in Faust
@@ -235,7 +228,7 @@ ma = library("maths.lib");
 si = library("signals.lib");
 
 declare name "Faust Wave Digital Model Library";
-declare version "0.1.1";
+declare version "0.2.0";
 
 
 
@@ -243,8 +236,9 @@ declare version "0.1.1";
 //=========================================================================================
 
 //----------------------`(wd.)resistor`--------------------------
-// Resistor
-// A basic adaptor implementing a resistor for use within Wave Digital Filter connection trees.
+// Adapted Resistor
+//
+// A basic node implementing a resistor for use within Wave Digital Filter connection trees.
 //
 // It should be used as a leaf/terminating element of the connection tree.
 //
@@ -263,6 +257,7 @@ declare version "0.1.1";
 // Note:
 // The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.2.1
 //----------------------------------------------------------
@@ -280,8 +275,9 @@ case{
 };
 
 
-//----------------------`(wd.)resistor_output`--------------------------
-// Resistor + voltage Out.
+//----------------------`(wd.)resistor_Vout`--------------------------
+// Adapted Resistor + voltage Out.
+//
 // A basic adaptor implementing a resistor for use within Wave Digital Filter connection trees.
 //
 // It should be used as a leaf/terminating element of the connection tree.
@@ -290,7 +286,7 @@ case{
 // #### Usage
 //
 // ```
-// rout(i) = resistor_output(i, R);
+// rout(i) = resistor_Vout(i, R);
 // buildtree( A : rout ) : _;
 // ```
 //
@@ -302,13 +298,15 @@ case{
 // Note: 
 // The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.2.1
 //----------------------------------------------------------
-declare resistor_output author "Dirk Roosenburg";
-declare resistor_output copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare resistor_output license "MIT-style STK-4.3 license";
-resistor_output = 
+declare resistor_Vout author "Dirk Roosenburg";
+declare resistor_Vout copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare resistor_Vout license "MIT-style STK-4.3 license";
+resistor_Vout = 
 case{
     (0, R) => 0, _*.5; 
     (1, R) => _, !; 
@@ -316,11 +314,14 @@ case{
     with{
         R0 = R; 
     };
+}with{
+    rho = 1; 
 };
 
 
-//----------------------`(wd.)resistor_output_current`--------------------------
+//----------------------`(wd.)resistor_Iout`--------------------------
 // Resistor + current Out.
+//
 // A basic adaptor implementing a resistor for use within Wave Digital Filter connection trees.
 //
 // It should be used as a leaf/terminating element of the connection tree.
@@ -329,7 +330,7 @@ case{
 // #### Usage
 //
 // ```
-// rout(i) = resistor_output_current(i, R);
+// rout(i) = resistor_Iout(i, R);
 // buildtree( A : rout ) : _;
 // ```
 //
@@ -341,13 +342,15 @@ case{
 // Note: 
 // The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.2.1
 //----------------------------------------------------------
-declare resistor_output_current author "Dirk Roosenburg";
-declare resistor_output_current copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare resistor_output_current license "MIT-style STK-4.3 license";
-resistor_output_current = 
+declare resistor_Iout author "Dirk Roosenburg";
+declare resistor_Iout copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare resistor_Iout license "MIT-style STK-4.3 license";
+resistor_Iout = 
 case{
     (0, R) => 0, _*.5/R; 
     (1, R) => _, !; 
@@ -359,7 +362,8 @@ case{
 
 
 //----------------------`(wd.)u_voltage`--------------------------
-// Ideal Voltage Source (Unadapted).
+// Unadapted Ideal Voltage Source
+//
 // An adaptor implementing an ideal voltage source within Wave Digital Filter connection trees.
 //
 // It should be used as the root/top element of the connection tree.
@@ -379,9 +383,11 @@ case{
 //
 // Note: 
 // Only usable as the root of a tree
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.2.2
 //----------------------------------------------------------
 declare u_voltage author "Dirk Roosenburg";
@@ -391,15 +397,18 @@ u_voltage =
 case{
     (0 , ein) => b0
     with{
-        b0(R0, a0) = 2*R0^(p-1)*ein -a0;
+        b0(R0, a0) = 2*R0^(rho-1)*ein -a0;
     };
     (1, ein) => !, !; 
     (2, ein) => 0; 
+}with{
+    rho = 1; 
 };
 
 
 //----------------------`(wd.)u_current`--------------------------
-// Resistive Current Source (Unadapted).
+// Unadapted Ideal Current Source
+//
 // An unadapted adaptor implementing an ideal current source within Wave Digital Filter connection trees.
 //
 // It should be used as the root/top element of the connection tree.
@@ -419,9 +428,11 @@ case{
 //
 // Note: 
 // Only usable as the root of a tree.
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.2.3
 //----------------------------------------------------------
 declare u_current author "Dirk Roosenburg";
@@ -431,15 +442,18 @@ u_current =
 case{
     (0 , jin) => b0
     with{
-        b0(R0, a0) = 2*R0^(p)*jin + a0;
+        b0(R0, a0) = 2*R0^(rho)*jin + a0;
     };
     (1, jin) => !, !; 
     (2, jin) => 0; 
+}with{
+    rho = 1; 
 };
 
 //----------------------`(wd.)resVoltage`--------------------------
-// Resistive Voltage Source.
-// An adaptor implementing a resitive voltage source within Wave Digital Filter connection trees.
+// Adapted Resistive Voltage Source
+//
+// An adaptor implementing a resistive voltage source within Wave Digital Filter connection trees.
 //
 // It should be used as a leaf/terminating element of the connection tree.
 // It is comprised of an ideal voltage source in series with a resistor.
@@ -455,13 +469,15 @@ case{
 // Where:
 //
 // * `i`: index used by model-building functions. Should never be user declared
-// * `R` : Resistance/Impedence of the series resistor in Ohms
+// * `R` : Resistance/Impedance of the series resistor in Ohms
 // * `ein` : Voltage/Potential of the ideal voltage source in Volts
 //
 // Note: 
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.2.4
 //----------------------------------------------------------
 declare resVoltage author "Dirk Roosenburg";
@@ -469,17 +485,20 @@ declare resVoltage copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosen
 declare resVoltage license "MIT-style STK-4.3 license";
 resVoltage = 
 case{
-    (0, R, ein) => R^(1-p)*ein;
+    (0, R, ein) => !, R^(1-rho)*ein;
     (1, R, ein) => _; 
     (2, R, ein) => R0
     with {
         R0 = R; 
     };
+}with{
+    rho = 1; 
 }; 
 
-//----------------------`(wd.)resVoltage_output`--------------------------
-// Resistive Voltage Source + voltage output.
-// An adaptor implementing a resitive voltage source within Wave Digital Filter connection trees.
+//----------------------`(wd.)resVoltage_Vout`--------------------------
+// Adapted Resistive Voltage Source + voltage output.
+//
+// An adaptor implementing an adapted resistive voltage source within Wave Digital Filter connection trees.
 //
 // It should be used as a leaf/terminating element of the connection tree.
 // It is comprised of an ideal voltage source in series with a resistor.
@@ -489,38 +508,43 @@ case{
 // #### Usage
 //
 // ```
-// vout(i) = resVoltage_output(i, R, ein);
+// vout(i) = resVoltage_Vout(i, R, ein);
 // buildtree( A : vout ) : _;
 // ```
 //
 // Where:
 //
 // * `i`: index used by model-building functions. Should never be user declared
-// * `R` : Resistance/Impedence of the series resistor in Ohms
+// * `R` : Resistance/Impedance of the series resistor in Ohms
 // * `ein` : Voltage/Potential across ideal voltage source in Volts
 //
 // Note: 
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.2.4
 //----------------------------------------------------------
-declare resVoltage_output author "Dirk Roosenburg";
-declare resVoltage_output copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare resVoltage_output license "MIT-style STK-4.3 license";
-resVoltage_output = 
+declare resVoltage_Vout author "Dirk Roosenburg";
+declare resVoltage_Vout copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare resVoltage_Vout license "MIT-style STK-4.3 license";
+resVoltage_Vout = 
 case{
-    (0, R, ein) => R^(1-p)*ein, _*.5 + R^(1-p)*ein*.5;
+    (0, R, ein) => R^(1-rho)*ein, _*.5 + R^(1-rho)*ein*.5;
     (1, R, ein) => _, !; 
     (2, R, ein) => R0
     with {
         R0 = R; 
     };
+}with{
+    rho = 1; 
 }; 
 
 //----------------------`(wd.)u_resVoltage`--------------------------
-// Resistive Voltage Source (Unadapted).
-// An unadapted adaptor implementing a resitive voltage source within Wave Digital Filter connection trees.
+// Unadapted Resistive Voltage Source
+//
+// An unadapted adaptor implementing a resistive voltage source within Wave Digital Filter connection trees.
 //
 // It should be used as the root/top element of the connection tree.
 // It is comprised of an ideal voltage source in series with a resistor.
@@ -536,14 +560,16 @@ case{
 // Where:
 //
 // * `i`: index used by model-building functions. Should never be user declared
-// * `R` : Resistance/Impedence of the series resistor in Ohms
+// * `R` : Resistance/Impedance of the series resistor in Ohms
 // * `ein` : Voltage/Potential across ideal voltage source in Volts
 //
 // Note: 
 // Only usable as the root of a tree.
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.2.4
 //----------------------------------------------------------
 declare u_resVoltage author "Dirk Roosenburg";
@@ -553,17 +579,20 @@ u_resVoltage =
 case {
     (0, R, ein) => b0
     with{
-        b0(R0, a0) = a0*(R - R0)/(R+R0) + ein*(2*R0^p)/(R + R0);
+        b0(R0, a0) = a0*(R - R0)/(R+R0) + ein*(2*R0^rho)/(R + R0);
     };
     (1, R, ein) => !, !; 
     (2, R, ein) => 0; 
 
+}with{
+    rho = 1; 
 };
 
 
 //----------------------`(wd.)resCurrent`--------------------------
-// Resistive Current Source.
-// An adaptor implementing a resitive current source within Wave Digital Filter connection trees.
+// Unadapted Resistive Current Source
+//
+// An adaptor implementing a resistive current source within Wave Digital Filter connection trees.
 //
 // It should be used as a leaf/terminating element of the connection tree.
 // It is comprised of an ideal current source in parallel with a resistor.
@@ -579,13 +608,15 @@ case {
 // Where:
 //
 // * `i`: index used by model-building functions. Should never be user declared.
-// * `R` : Resistance/Impedence of the parallel resistor in Ohms
+// * `R` : Resistance/Impedance of the parallel resistor in Ohms
 // * `jin` : Current through the ideal current source in Amps
 //
 // Note: 
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.2.5
 //----------------------------------------------------------
 declare resCurrent author "Dirk Roosenburg";
@@ -593,17 +624,20 @@ declare resCurrent copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosen
 declare resCurrent license "MIT-style STK-4.3 license";
 resCurrent =
 case {
-    (0, R, jin) => !, 2*R^(p)*jin;
+    (0, R, jin) => !, 2*R^(rho)*jin;
     (1, R, jin) => _; 
     (2, R, jin) => R0
     with {
         R0 = R; 
     };
+}with{
+    rho = 1; //assume voltage waves
 }; 
 
 //----------------------`(wd.)u_resCurrent`--------------------------
-// Resistive Current Source (Uadapted).
-// An unadapted adaptor implementing a resitive current source within Wave Digital Filter connection trees.
+// Unadapted Resistive Current Source 
+//
+// An unadapted adaptor implementing a resistive current source within Wave Digital Filter connection trees.
 //
 // It should be used as the root/top element of the connection tree
 // It is comprised of an ideal current source in parallel with a resistor
@@ -619,14 +653,16 @@ case {
 // Where:
 //
 // * `i`: index used by model-building functions. Should never be user declared.
-// * `R` : Resistance/Impedence of the series resistor in Ohms
+// * `R` : Resistance/Impedance of the series resistor in Ohms
 // * `jin` : Current through the ideal current source in Amps
 //
 // Note: 
 // Only usable as the root of a tree.
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.2.5
 //----------------------------------------------------------
 declare u_resCurrent author "Dirk Roosenburg";
@@ -636,18 +672,21 @@ u_resCurrent =
 case {
     (0, R, jin) => b0
     with{
-        b0(R0, a0) = a0*(R - R0)/(R + R0) + jin*(2*R*R0^p)/(R + R0);
+        b0(R0, a0) = a0*(R - R0)/(R + R0) + jin*(2*R*R0^rho)/(R + R0);
     };
     (1, R, jin) => !, !; 
     (2, R, jin) => 0; 
 
+}with{
+    rho = 1; //assume voltage waves
 };
 
 //TODO
 //add short circuit (1.2.6), add open circuit (1.2.7)
 
 //----------------------`(wd.)u_switch`--------------------------
-// Ideal Switch (Unadapted).
+// Unadapted Ideal Switch
+//
 // An unadapted adaptor implementing an ideal switch for Wave Digital Filter connection trees.
 //
 // It should be used as the root/top element of the connection tree
@@ -666,15 +705,17 @@ case {
 //
 // Note: 
 // Only usable as the root of a tree
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.2.8
 //----------------------------------------------------------
-declare u_Switch author "Dirk Roosenburg";
-declare u_Switch copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare u_Switch license "MIT-style STK-4.3 license";
-u_Switch = 
+declare u_switch author "Dirk Roosenburg";
+declare u_switch copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare u_switch license "MIT-style STK-4.3 license";
+u_switch = 
 case {
     (0, lambda) => b0
     with{
@@ -686,10 +727,11 @@ case {
 
 //=============================Reactive One Port Adaptors=================================
 //========================================================================================
-//TODO - add mobius transform or alpha transform versions
+//TODO - add mobius transform and alpha transform digitizations
 
 //----------------------`(wd.)capacitor`--------------------------
-// Capacitor.
+// Adapted Capacitor
+//
 // A basic adaptor implementing a capacitor for use within Wave Digital Filter connection trees.
 //
 // It should be used as a leaf/terminating element of the connection tree.
@@ -705,12 +747,14 @@ case {
 // Where:
 //
 // * `i`: index used by model-building functions. Should never be user declared.
-// * `R` : Capacitance/Impedence of the capacitor being modeled in Farads. 
+// * `R` : Capacitance/Impedance of the capacitor being modeled in Farads. 
 //
 // Note:
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.3.1
 //----------------------------------------------------------
 declare capacitor author "Dirk Roosenburg";
@@ -724,10 +768,13 @@ case{
     with {
         R0 = t/(2*R); 
     };
+}with{
+    t = 1/ma.SR; //sampling interval
 };
 
-//----------------------`(wd.)capacitor_output`--------------------------
-// Capacitor + voltage out.
+//----------------------`(wd.)capacitor_Vout`--------------------------
+// Adapted Capacitor + voltage out
+//
 // A basic adaptor implementing a capacitor for use within Wave Digital Filter connection trees.
 //
 // It should be used as a leaf/terminating element of the connection tree.
@@ -737,7 +784,7 @@ case{
 // #### Usage
 //
 // ```
-// cout(i) = capacitor_output(i, R);
+// cout(i) = capacitor_Vout(i, R);
 // buildtree( A : cout ) : _;
 // ```
 //
@@ -749,13 +796,15 @@ case{
 // Note: 
 // The adaptor must be declared as a seperate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.3.1
 //----------------------------------------------------------
-declare capacitor_output author "Dirk Roosenburg";
-declare capacitor_output copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare capacitor_output license "MIT-style STK-4.3 license";
-capacitor_output = 
+declare capacitor_Vout author "Dirk Roosenburg";
+declare capacitor_Vout copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare capacitor_Vout license "MIT-style STK-4.3 license";
+capacitor_Vout = 
 case{
     (0, R) => b0
     with{
@@ -766,10 +815,13 @@ case{
     with {
         R0 = t/(2*R); 
     };
+}with{
+    t = 1/ma.SR; //sampling interval
 };
 
 //----------------------`(wd.)inductor`--------------------------
-// Inductor.
+// Unadapted Inductor
+//
 // A basic adaptor implementing an inductor for use within Wave Digital Filter connection trees.
 //
 // It should be used as a leaf/terminating element of the connection tree.
@@ -785,12 +837,14 @@ case{
 // Where:
 //
 // * `i`: index used by model-building functions. Should never be user declared
-// * `R` : Inductance/Impedence of the inductor being modeled in Henries
+// * `R` : Inductance/Impedance of the inductor being modeled in Henries
 //
 // Note: 
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.3.2
 //----------------------------------------------------------
 declare inductor author "Dirk Roosenburg";
@@ -804,10 +858,13 @@ case{
     with {
         R0 = (2*R)/t; 
     };
+}with{
+    t = 1/ma.SR; //sampling interval
 };
 
-//----------------------`(wd.)inductor_output`--------------------------
-// Inductor + Voltage out.
+//----------------------`(wd.)inductor_Vout`--------------------------
+// Unadapted Inductor + Voltage out
+//
 // A basic adaptor implementing an inductor for use within Wave Digital Filter connection trees.
 //
 // It should be used as a leaf/terminating element of the connection tree.
@@ -817,25 +874,27 @@ case{
 // #### Usage
 //
 // ```
-// lout(i) = inductor_output(i, R);
+// lout(i) = inductor_Vout(i, R);
 // buildtree( A : lout ) : _;
 // ```
 //
 // Where:
 //
 // * `i`: index used by model-building functions. Should never be user declared
-// * `R` : Inductance/Impedence of the inductor being modeled in Henries
+// * `R` : Inductance/Impedance of the inductor being modeled in Henries
 //
 // Note: 
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.3.2
 //----------------------------------------------------------
-declare inductor_output author "Dirk Roosenburg";
-declare inductor_output copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare inductor_output license "MIT-style STK-4.3 license";
-inductor_output = 
+declare inductor_Vout author "Dirk Roosenburg";
+declare inductor_Vout copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare inductor_Vout license "MIT-style STK-4.3 license";
+inductor_Vout = 
 case{
     (0, R) => b0
     with{
@@ -846,13 +905,16 @@ case{
     with {
         R0 = (2*R)/t; 
     };
+}with{
+    t = 1/ma.SR; //sampling interval
 };
 
 //===============================Nonlinear One Port Adaptors==============================
 //========================================================================================
 
 //----------------------`(wd.)u_idealDiode`--------------------------
-// Ideal Diode (Unadapted).
+// Unadapted Ideal Diode
+//
 // An unadapted adaptor implementing an ideal diode for Wave Digital Filter connection trees.
 //
 // It should be used as the root/top element of the connection tree.
@@ -866,7 +928,9 @@ case{
 // Note: 
 // Only usable as the root of a tree
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 3.2.3
 //----------------------------------------------------------
 declare u_idealDiode author "Dirk Roosenburg";
@@ -883,7 +947,8 @@ case{
 };
 
 //----------------------`(wd.)u_chua`--------------------------
-// Chua Diode (Unadapted).
+// Unadapted Chua Diode
+//
 // An adaptor implementing the chua diode / non-linear resistor within Wave Digital Filter connection trees.
 //
 // It should be used as the root/top element of the connection tree.
@@ -904,9 +969,11 @@ case{
 //
 // Note: 
 // Only usable as the root of a tree.
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // Meerkotter and Scholz, "Digital Simulation of Nonlinear Circuits by Wave Digital Filter Principles"
 //----------------------------------------------------------
 declare u_chua author "Dirk Roosenburg";
@@ -930,9 +997,9 @@ case{
 
 //----------------------`(wd.)lambert`--------------------------
 // An implementation of the lambert function.
-// It uses Halley's method of iteration to aproximate the output.
+// It uses Halley's method of iteration to approximate the output.
 // Included in the WD library for use in non-linear diode models.
-// Adapted from  K M Brigg's c++ lambert function approximator.
+// Adapted from  K M Brigg's c++ lambert function approximation.
 //
 // #### Usage
 //
@@ -983,14 +1050,15 @@ with{
 
 
 //----------------------`(wd.)u_diodePair`--------------------------
-// A pair of diodes facing in opposite directions.
+// Unadapted pair of diodes facing in opposite directions.
+//
 // An unadapted adaptor implementing two antiparallel diodes for Wave Digital Filter connection trees.
 // The behavior is approximated using Schottkey's ideal diode law.
 //
 // #### Usage
 //
 // ```
-// d1 = u_diodePair(i, Is, Vt);
+// d1(i) = u_diodePair(i, Is, Vt);
 // buildtree( d1 : B );
 // ```
 //
@@ -1003,7 +1071,9 @@ with{
 // Note: 
 // Only usable as the root of a tree.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner et al. "An Improved and Generalized Diode Clipper Model for Wave Digital Filters"
 //----------------------------------------------------------
 declare u_diodePair author "Dirk Roosenburg";
@@ -1013,7 +1083,7 @@ u_diodePair =
 case{
     (0, Is, Vt) => b1
     with{
-        b1(R1, a1) = a1 + 2*R1*Is - 2*Vt*lambert((R1*Is/Vt*(((a1+R1*Is)/Vt), 3) : exp));
+        b1(R1, a1) = a1 + 2*R1*Is - 2*Vt*lambert((R1*Is/Vt*(a1+R1*Is))/Vt), 3) : exp;
     };
     (1, Is, Vt) => !, !; 
     (2, Is, Vt) => 0; 
@@ -1021,14 +1091,15 @@ case{
 
 
 //----------------------`(wd.)u_diodeSingle`--------------------------
-// A single diode.
+// Unadapted single diode.
+//
 // An unadapted adaptor implementing a single diode for Wave Digital Filter connection trees.
 // The behavior is approximated using Schottkey's ideal diode law.
 //
 // #### Usage
 //
 // ```
-// d1 = u_diodeSingle(i, Is, Vt);
+// d1(i) = u_diodeSingle(i, Is, Vt);
 // buildtree( d1 : B );
 // ```
 //
@@ -1041,7 +1112,9 @@ case{
 // Note: 
 // Only usable as the root of a tree
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner et al. "An Improved and Generalized Diode Clipper Model for Wave Digital Filters"
 //----------------------------------------------------------
 declare u_diodeSingle author "Dirk Roosenburg";
@@ -1058,14 +1131,15 @@ case{
 };
 
 //----------------------`(wd.)u_diodeAntiparallel`--------------------------
-// A set of antiparallel diodes with M diodes facing forwards and N diodes facing backwards.
+// Unadapted set of antiparallel diodes with M diodes facing forwards and N diodes facing backwards.
+//
 // An unadapted adaptor implementing antiparallel diodes for Wave Digital Filter connection trees.
 // The behavior is approximated using Schottkey's ideal diode law.
 //
 // #### Usage
 //
 // ```
-// d1 = u_diodeAntiparallel(i, Is, Vt);
+// d1(i) = u_diodeAntiparallel(i, Is, Vt);
 // buildtree( d1 : B );
 // ```
 //
@@ -1078,7 +1152,9 @@ case{
 // Note: 
 // Only usable as the root of a tree
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner et al. "An Improved and Generalized Diode Clipper Model for Wave Digital Filters"
 //----------------------------------------------------------
 declare u_diodeAntiparallel author "Dirk Roosenburg";
@@ -1105,62 +1181,70 @@ case{
 //========================================================================================
 
 
-//----------------------`(wd.)u_parallel_2`--------------------------
-// 2-port parallel adaptor (Unadapted).
+//----------------------`(wd.)u_parallel2Port`--------------------------
+// Unadapted 2-port parallel connection
+//
 // An unadapted adaptor implementing a 2-port parallel connection between adaptors for Wave Digital Filter connection trees.
 // Elements connected to this adaptor will behave as if connected in parallel in circuit.
 //
 // #### Usage
 //
 // ```
-// buildtree( u_parallel_2 : (A, B) );
+// buildtree( u_parallel2Port : (A, B) );
 // ```
 //
 // Note: 
 // Only usable as the root of a tree.
 // This adaptor has no user-accessible parameters. 
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.4.1
 //----------------------------------------------------------
-declare u_parallel_2 author "Dirk Roosenburg";
-declare u_parallel_2 copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare u_parallel_2 license "MIT-style STK-4.3 license";
-u_parallel_2 = 
+declare u_parallel2Port author "Dirk Roosenburg";
+declare u_parallel2Port copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare u_parallel2Port license "MIT-style STK-4.3 license";
+u_parallel2Port = 
 case{
     (0) => u_par
     with{ 
-        u_par = si.bus(4) <: b1, b2;
-        b0(R0, R1, a0, a1) = (-a0*(R0-R1) + a1*(2*R0^p*R1^(1-p)))/(R0+R1);
-        b1(R0, R1, a0, a1) = (a1*(R0-R1) + a0*(2*R0^(1-p)*R1^p))/(R0+R1);
+        u_par = si.bus(4) <: b0, b1;
+        b0(R0, R1, a0, a1) = (-a0*(R0-R1) + a1*(2*R0^rho*R1^(1-rho)))/(R0+R1);
+        b1(R0, R1, a0, a1) = (a1*(R0-R1) + a0*(2*R0^(1-rho)*R1^rho))/(R0+R1);
     };
     (1) => !, !, !, !;
     (2) => 0; 
+}with{
+    rho = 1; //assume voltage waves
 };
 
 
-//----------------------`(wd.)parallel_2`--------------------------
-// 2-port parallel adaptor.
+//----------------------`(wd.)parallel2Port`--------------------------
+// Adapted 2-port parallel connection
+//
 // An adaptor implementing a 2-port parallel connection between adaptors for Wave Digital Filter connection trees.
 // Elements connected to this adaptor will behave as if connected in parallel in circuit.
 //
 // #### Usage
 //
 // ```
-// buildtree( A : parallel_2 : B );
+// buildtree( A : parallel2Port : B );
 // ```
 //
 // Note: 
 // This adaptor has no user-accessible parameters. 
 // It should be used within the connection tree with one previous and one forward adaptor.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.4.1
 //----------------------------------------------------------
-declare parallel_2 author "Dirk Roosenburg";
-declare parallel_2 copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare parallel_2 license "MIT-style STK-4.3 license";
-parallel_2 = 
+declare parallel2Port author "Dirk Roosenburg";
+declare parallel2Port copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare parallel2Port license "MIT-style STK-4.3 license";
+parallel2Port = 
 case{
     (0) => par_down
     with{
@@ -1178,62 +1262,70 @@ case{
     };
 };
 
-//----------------------`(wd.)u_series_2`--------------------------
-// 2-port series adaptor (Unadapted).
+//----------------------`(wd.)u_series2Port`--------------------------
+// Unadapted 2-port series connection
+//
 // An unadapted adaptor implementing a 2-port series connection between adaptors for Wave Digital Filter connection trees.
 // Elements connected to this adaptor will behave as if connected in series in circuit.
 //
 // #### Usage
 //
 // ```
-// buildtree( u_series_2 : (A, B) );
+// buildtree( u_series2Port : (A, B) );
 // ```
 //
 // Note: 
 // Only usable as the root of a tree.
 // This adaptor has no user-accessible parameters. 
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.4.1
 //----------------------------------------------------------
-declare u_series_2 author "Dirk Roosenburg";
-declare u_series_2 copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare u_series_2 license "MIT-style STK-4.3 license";
-u_series_2 = 
+declare u_series2Port author "Dirk Roosenburg";
+declare u_series2Port copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare u_series2Port license "MIT-style STK-4.3 license";
+u_series2Port = 
 case{
     (0) => u_ser
     with{ 
-        u_ser = si.bus(4) <: b1, b2;
-        b0(R0, R1, a0, a1) = (-a0*(R0-R1) - a1*(2*R0^p*R1^(1-p)))/(R0+R1);
-        b1(R0, R1, a0, a1) = (a1*(R0-R1) - a0*(2*R0^(1-p)*R1^p))/(R0+R1);
+        u_ser = si.bus(4) <: b0, b1;
+        b0(R0, R1, a0, a1) = (-a0*(R0-R1) - a1*(2*R0^rho*R1^(1-rho)))/(R0+R1);
+        b1(R0, R1, a0, a1) = (a1*(R0-R1) - a0*(2*R0^(1-rho)*R1^rho))/(R0+R1);
     };
     (1) => !, !, !, !;
     (2) => 0; 
+}with{
+    rho = 1; //assume voltage waves
 };
 
 
-//----------------------`(wd.)series_2`--------------------------
-// 2-port series adaptor.
+//----------------------`(wd.)series2Port`--------------------------
+// Adapted 2-port series connection
+//
 // An adaptor implementing a 2-port series connection between adaptors for Wave Digital Filter connection trees.
 // Elements connected to this adaptor will behave as if connected in series in circuit.
 //
 // #### Usage
 //
 // ```
-// buildtree( A : series_2 : B );
+// buildtree( A : series2Port : B );
 // ```
 //
 // Note: 
 // This adaptor has no user-accessible parameters. 
 // It should be used within the connection tree with one previous and one forward adaptor.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.4.1
 //----------------------------------------------------------
-declare series_2 author "Dirk Roosenburg";
-declare series_2 copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare series_2 license "MIT-style STK-4.3 license";
-series_2 = 
+declare series2Port author "Dirk Roosenburg";
+declare series2Port copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare series2Port license "MIT-style STK-4.3 license";
+series2Port = 
 case{
     (0) => ser_down
     with{
@@ -1252,15 +1344,16 @@ case{
 };
 
 
-//----------------------`(wd.)parallel_current`--------------------------
-// 2-port parallel adaptor + ideal current source.
+//----------------------`(wd.)parallelCurrent`--------------------------
+// Adapted 2-port parallel connection + ideal current source
+//
 // An adaptor implementing a 2-port series connection and internal idealized current source between adaptors for Wave Digital Filter connection trees.
 // This adaptor connects the two connected elements and an additional ideal current source in parallel.
 //
 // #### Usage
 //
 // ```
-// i1 = parallel_current(i, jin);
+// i1(i) = parallelCurrent(i, jin);
 // buildtree(A : i1 : B);
 // ```
 //
@@ -1270,43 +1363,48 @@ case{
 // * `jin` :  Current through the ideal current source in Amps
 //
 // Note: 
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // It should be used within a connection tree with one previous and one forward adaptor.
 // Correct implementation is shown above.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.4.2
 //----------------------------------------------------------
-declare parallel_current author "Dirk Roosenburg";
-declare parallel_current copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare parallel_current license "MIT-style STK-4.3 license";
-parallel_current = 
+declare parallelCurrent author "Dirk Roosenburg";
+declare parallelCurrent copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare parallelCurrent license "MIT-style STK-4.3 license";
+parallelCurrent = 
 case{
     (0, jin) => par_current_down
     with{
         par_current_down = b1; 
-        b1(R1, a0, a1) = a0 + R1^p*jin;  
+        b1(R1, a0, a1) = a0 + R1^rho*jin;  
     };
     (1, jin) => par_current_up
     with{
         par_current_up = b0; 
-        b0(R1, a1) = a1 + R1^p*jin; 
+        b0(R1, a1) = a1 + R1^rho*jin; 
     };
     (2, jin) => R0
     with{
         R0(R1) = R1; 
     };
+}with{
+    rho = 1; //assume voltage waves
 };
 
 
-//----------------------`(wd.)series_voltage`--------------------------
-// 2-port series adaptor + ideal voltage source.
+//----------------------`(wd.)seriesVoltage`--------------------------
+// Adapted 2-port series connection + ideal voltage source.
+//
 // An adaptor implementing a 2-port series connection and internal ideal voltage source between adaptors for Wave Digital Filter connection trees.
 // This adaptor connects the two connected adaptors and an additional ideal voltage source in series.
 //
 // #### Usage
 //
 // ```
-// v1 = series_voltage(i, vin)
+// v1(i) = seriesVoltage(i, vin)
 // buildtree( A : v1 : B );
 // ```
 //
@@ -1316,29 +1414,226 @@ case{
 // * `vin` :  voltage across the ideal current source in Volts
 //
 // Note: 
-// The adaptor must be declared as a seperate function before integration into the connection tree.
+// The adaptor must be declared as a separate function before integration into the connection tree.
 // It should be used within the connection tree with one previous and one forward adaptor.
+//
 // #### Reference
+//
 // K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.4.2
 //----------------------------------------------------------
-declare series_voltage author "Dirk Roosenburg";
-declare series_voltage copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare series_voltage license "MIT-style STK-4.3 license";
-series_voltage = 
+declare seriesVoltage author "Dirk Roosenburg";
+declare seriesVoltage copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare seriesVoltage license "MIT-style STK-4.3 license";
+seriesVoltage = 
 case{
     (0, vin) => ser_down
     with{
         ser_down = b1; 
-        b1(R1, a0, a1) = -a0 - R1^(p-1)*vin;  
+        b1(R1, a0, a1) = -a0 - R1^(rho-1)*vin;  
     };
     (1, vin) => ser_up
     with{
         ser_up = b0; 
-        b0(R1, a1) = -a1 - R1^(p-1)*vin; 
+        b0(R1, a1) = -a1 - R1^(rho-1)*vin; 
     };
     (2, vin) => R0
     with{
         R0(R1) = R1; 
+    };
+}with{
+    rho = 1; //assume voltage waves
+};
+
+//----------------------`(wd.)u_transformer`--------------------------
+// Unadapted ideal transformer
+//
+// An adaptor implementing an ideal transformer for Wave Digital Filter connection trees.
+// The first downward-facing port corresponds to the primary winding connections, and the second downward-facing port to the secondary winding connections
+//
+// #### Usage
+//
+// ```
+// t1(i) = u_transformer(i, tr);
+// buildtree(t1 : (A , B));
+// ```
+//
+// Where:
+//
+// * `i`: index used by model-building functions. Should never be user declared
+// * `tr` :  the turn ratio between the windings on the primary and secondary coils
+//
+// Note: 
+// The adaptor must be declared as a separate function before integration into the connection tree.
+// It may only be used as the root of the connection tree with two forward nodes.
+//
+//
+// #### Reference
+//
+// K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.4.3
+//----------------------------------------------------------
+declare u_transformer author "Dirk Roosenburg";
+declare u_transformer copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare u_transformer license "MIT-style STK-4.3 license";
+u_transformer(i, n) = u_genericNode(i, transformer_scatter)
+with{
+    matrix(M,N,f) = si.bus(N) <: ro.interleave(N,M) : par(n,N, par(m,M,*(f(m+1,n+1)))) :> si.bus(M);
+
+    transformer_scatter(R0, R1) = matrix(2, 2, s)
+    with{
+        s(1,1) =-1*(R0-n^2*R1)/(R0+n^2*R1);
+        s(1,2) = (2*n*R0^rho*R1^(1-rho))/(R0+n^2*R1);
+        s(2,1) = (2*n*R0^(1-rho)*R1^rho)/(R0+n^2*R1);
+        s(2,2) = (R0-n^2*R1)/(R0+n^2*R1);
+        s(i,j) = 10; 
+
+        rho = 1; //assume voltage waves
+    };
+};
+
+//----------------------`(wd.)transformer`--------------------------
+// Adapted ideal transformer
+//
+// An adaptor implementing an ideal transformer for Wave Digital Filter connection trees.
+// The upward-facing port corresponds to the primary winding connections, and the downward-facing port to the secondary winding connections
+//
+// #### Usage
+//
+// ```
+// t1(i) = transformer(i, tr);
+// buildtree(A : t1 : B);
+// ```
+//
+// Where:
+//
+// * `i`: index used by model-building functions. Should never be user declared
+// * `tr` :  the turn ratio between the windings on the primary and secondary coils
+//
+// Note: 
+// The adaptor must be declared as a separate function before integration into the connection tree.
+// It should be used within the connection tree with one backward and one forward nodes.
+//
+// #### Reference
+//
+// K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.4.3
+//----------------------------------------------------------
+declare transformer author "Dirk Roosenburg";
+declare transformer copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare transformer license "MIT-style STK-4.3 license";
+transformer(i, n) = genericNode(i, transformer_scatter, transformer_upPortRes)
+with{
+    matrix(M,N,f) = si.bus(N) <: ro.interleave(N,M) : par(n,N, par(m,M,*(f(m+1,n+1)))) :> si.bus(M);
+
+    transformer_upPortRes(R1) = n^2*R1; //equation for upward-facing port resistance
+
+    transformer_scatter(R1) = matrix(2, 2, s)
+    with{
+        s(1,1) =-1*(R0-n^2*R1)/(R0+n^2*R1);
+        s(1,2) = (2*n*R0^rho*R1^(1-rho))/(R0+n^2*R1);
+        s(2,1) = (2*n*R0^(1-rho)*R1^rho)/(R0+n^2*R1);
+        s(2,2) = (R0-n^2*R1)/(R0+n^2*R1);
+        s(i,j) = 10; 
+
+        rho = 1; //assume voltage waves
+
+        R0 = n^2*R1; //adapting condition
+    };
+};
+
+
+//----------------------`(wd.)u_transformerActive`--------------------------
+// Unadapted ideal active transformer
+//
+// An adaptor implementing an ideal transformer for Wave Digital Filter connection trees.
+// The first downward-facing port corresponds to the primary winding connections, and the second downward-facing port to the secondary winding connections
+//
+// #### Usage
+//
+// ```
+// t1(i) = u_transformerActive(i, gamma1, gamma2);
+// buildtree(t1 : (A , B));
+// ```
+//
+// Where:
+//
+// * `i`: index used by model-building functions. Should never be user declared
+// * `gamma1` :  the turn ratio describing the voltage relationship between the primary and secondary coils
+// * `gamma2` :  the turn ratio describing the current relationship between the primary and secondary coils
+//
+// Note: 
+// The adaptor must be declared as a separate function before integration into the connection tree.
+// It may only be used as the root of the connection tree with two forward nodes.
+//
+// #### Reference
+//
+// K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.4.3
+//----------------------------------------------------------
+declare u_transformerActive author "Dirk Roosenburg";
+declare u_transformerActive copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare u_transformerActive license "MIT-style STK-4.3 license";
+u_transformerActive(i, gamma1, gamma2) = u_genericNode(i, transformerActive_scatter)
+with{
+    matrix(M,N,f) = si.bus(N) <: ro.interleave(N,M) : par(n,N, par(m,M,*(f(m+1,n+1)))) :> si.bus(M);
+
+    transformerActive_scatter(R0, R1) = matrix(2, 2, s)
+    with{
+        s(1,1) =-1*(R0-gamma1*gamma2*R1)/(R0+gamma1*gamma2*R1);
+        s(1,2) = (2*gamma1*R0^rho*R1^(1-rho))/(R0+gamma1*gamma2*R1);
+        s(2,1) = ((2*gamma2*R0^(1-rho)*R1^rho/(R0+gamma1*gamma2*R1);
+        s(2,2) = (R0-gamma1*gamma2*R1)/(R0+gamma1*gamma2*R1);
+        s(i,j) = 10; 
+
+        rho = 1; //assume voltage waves
+    };
+};
+
+
+//----------------------`(wd.)transformerActive`--------------------------
+// Adapted ideal active transformer
+//
+// An adaptor implementing an ideal active transformer for Wave Digital Filter connection trees.
+// The upward-facing port corresponds to the primary winding connections, and the downward-facing port to the secondary winding connections
+//
+// #### Usage
+//
+// ```
+// t1(i) = transformerActive(i, gamma1, gamma2);
+// buildtree(A : t1 : B);
+// ```
+//
+// Where:
+//
+// * `i`: index used by model-building functions. Should never be user declared
+// * `gamma1` :  the turn ratio describing the voltage relationship between the primary and secondary coils
+// * `gamma2` :  the turn ratio describing the current relationship between the primary and secondary coils
+//
+// Note: 
+// The adaptor must be declared as a separate function before integration into the connection tree.
+// It should be used within the connection tree with two forward nodes.
+//
+// #### Reference
+//
+// K. Werner, "Virtual Analog Modeling of Audio Circuitry Using Wave Digital Filters", 1.4.3
+//----------------------------------------------------------
+declare transformerActive author "Dirk Roosenburg";
+declare transformerActive copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare transformerActive license "MIT-style STK-4.3 license";
+transformerActive(i, gamma1, gamma2) = genericNode(i, transformerActive_scatter, transformerActive_upPortRes)
+with{
+    matrix(M,N,f) = si.bus(N) <: ro.interleave(N,M) : par(n,N, par(m,M,*(f(m+1,n+1)))) :> si.bus(M);
+
+    transformerActive_upPortRes(R1) = gamma1*gamma2*R1; //equation for upward-facing port resistance
+
+    transformerActive_scatter(R1) = matrix(2, 2, s)
+    with{
+        s(1,1) =-1*(R0-gamma1*gamma2*R1)/(R0+gamma1*gamma2*R1);
+        s(1,2) = (2*gamma1*R0^rho*R1^(1-rho))/(R0+gamma1*gamma2*R1);
+        s(2,1) = ((2*gamma2*R0^(1-rho)*R1^rho/(R0+gamma1*gamma2*R1);
+        s(2,2) = (R0-gamma1*gamma2*R1)/(R0+gamma1*gamma2*R1);
+        s(i,j) = 10; 
+
+        rho = 1; //assume voltage waves
+
+        R0 = gamma1*gamma2*R1; //adapting condition
     };
 };
 
@@ -1348,7 +1643,8 @@ case{
 
 
 //----------------------`(wd.)parallel`--------------------------
-// 3-port parallel adaptor.
+// Adapted 3-port parallel connection
+//
 // An adaptor implementing a 3-port parallel connection between adaptors for Wave Digital Filter connection trees.
 // This adaptor is used to connect adaptors simulating components connected in parallel in the circuit.
 //
@@ -1361,7 +1657,9 @@ case{
 // Note: 
 // This adaptor has no user-accessible parameters. 
 // It should be used within the connection tree with one previous and two forward adaptors.
+//
 // #### Reference
+//
 // K. Werner Dissertation, 1.5.1
 //----------------------------------------------------------
 declare parallel author "Dirk Roosenburg";
@@ -1389,7 +1687,8 @@ case{
 
 
 //----------------------`(wd.)series`--------------------------
-// 3-port series adaptor.
+// Adapted 3-port series connection
+//
 // An adaptor implementing a 3-port series connection between adaptors for Wave Digital Filter connection trees.
 // This adaptor is used to connect adaptors simulating components connected in series in the circuit.
 //
@@ -1403,12 +1702,14 @@ case{
 // Note: 
 // This adaptor has no user-accessible parameters. 
 // It should be used within the connection tree with one previous and two forward adaptors.
+//
 // #### Reference
+//
 // K. Werner Dissertation, 1.5.2
 //----------------------------------------------------------
-declare zero author "Dirk Roosenburg";
-declare zero copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
-declare zero license "MIT-style STK-4.3 license";
+declare series author "Dirk Roosenburg";
+declare series copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare series license "MIT-style STK-4.3 license";
 series= 
 case{
 
@@ -1429,14 +1730,268 @@ case{
     };
 };
 
+//====================================R-Type Adaptors=====================================
+//========================================================================================
 
 
-//constant declrations for library
-p = 1; 
-//some functions are declared in terms of p (rho) in advance of support of multiple kinds of waves within the system. 
-//multiple waves are currently unsupported, only voltage waves are currently used.
+//----------------------`(wd.)u_sixportPassive`--------------------------
+// Unadapted six-port rigid connection
+//
+// An adaptor implementing a six-port passive rigid connection between elements. 
+// It implements the simplest possible rigid connection found in the Fender Bassman Tonestack circuit
+// 
+//
+// #### Usage
+//
+// ```
+//
+// tree =  u_sixportPassive : (A, B, C, D, E, F));
+// ```
+//
+// Note: 
+// This adaptor has no user-accessible parameters. 
+// It should be used within the connection tree with six forward adaptors.
+//
+// #### Reference
+//
+// K. Werner Dissertation, 2.1.5
+//----------------------------------------------------------
+declare u_sixportPassive author "Dirk Roosenburg";
+declare u_sixportPassive copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare u_sixportPassive license "MIT-style STK-4.3 license";
+u_sixportPassive(i) = genericNode(i, sixport_scatter)
+with{
+    sixport_scatter(Ra, Rb, Rc, Rd, Re, Rf) =  matrix(6, 6, mtx)
+    with{
+        mtx  =
+        case{
+            (1, 1) => ((-Ra)*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf   + Rd*(Re + Rf)) +   Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (1, 2) => (2*Ra*((Rc + Re)*Rf + Rd*(Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (1, 3) => (2*Ra*(Rb*Rd + Re*Rf + Rd*(Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (1, 4) => (-1)*((2*Ra*(Rb*(Rc + Re) + Rc*(Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (1, 5) => (2*Ra*(Rb*Rd - Rc*Rf))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (1, 6) => (-1)*((2*Ra*(Rc*Re + Rb*(Rc + Rd + Re)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (2, 1) => (2*Rb*((Rc + Re)*Rf + Rd*(Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (2, 2) => (Ra*(Rd*Re - Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) - Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) +   Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (2, 3) => (-1)*((2*Rb*(Ra*Re + Re*Rf + Rd*(Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (2, 4) => (-2*Ra*Rb*Re + 2*Rb*Rc*Rf)/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (2, 5) => (2*Rb*(Ra*(Rc + Rd) + Rc*(Rd + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (2, 6) => (-1)*((2*Rb*(Rc*Rd + Ra*(Rc + Rd + Re)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (3, 1) => (2*Rc*(Rb*Rd + Re*Rf + Rd*(Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (3, 2) => (-1)*((2*Rc*(Ra*Re + Re*Rf + Rd*(Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (3, 3) => 1 - (2*Rc*(Rd*Re + Rd*Rf + Re*Rf + Rb*(Rd + Rf) + Ra*(Rb + Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (3, 4) => (-1)*((2*Rc*(Rb*Rf + Ra*(Rb + Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (3, 5) => (-1)*((2*Rc*(Ra*(Rb + Rf) + Rb*(Rd + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (3, 6) => (2*Rc*(Rb*Rd - Ra*Re))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (4, 1) => (-1)*((2*Rd*(Rb*(Rc + Re) + Rc*(Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (4, 2) => (-2*Ra*Rd*Re + 2*Rc*Rd*Rf)/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (4, 3) => (-1)*((2*Rd*(Rb*Rf + Ra*(Rb + Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (4, 4) => 1 - (2*Rd*(Rc*(Re + Rf) + Ra*(Rb + Re + Rf) + Rb*(Rc + Re + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (4, 5) => (-1)*((2*Rd*((Rb + Rc)*Rf + Ra*(Rb + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (4, 6) => (-1)*((2*Rd*((Ra + Rc)*Re + Rb*(Rc + Re)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (5, 1) => (2*Re*(Rb*Rd - Rc*Rf))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (5, 2) => (2*Re*(Ra*(Rc + Rd) + Rc*(Rd + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (5, 3) => (-1)*((2*Re*(Ra*(Rb + Rf) + Rb*(Rd + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (5, 4) => (-1)*((2*Re*((Rb + Rc)*Rf + Ra*(Rb + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (5, 5) => 1 - (2*Re*((Rb + Rc)*(Rd + Rf) + Ra*(Rb + Rc + Rd + Rf)))/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (5, 6) => (2*((Rb + Rc)*Rd + Ra*(Rc + Rd))*Re)/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (6, 1) => (-1)*((2*(Rc*Re + Rb*(Rc + Rd + Re))*Rf)/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (6, 2) => (-1)*((2*(Rc*Rd + Ra*(Rc + Rd + Re))*Rf)/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (6, 3) => (2*(Rb*Rd - Ra*Re)*Rf)/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (6, 4) => (-1)*((2*((Ra + Rc)*Re + Rb*(Rc + Re))*Rf)/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf))));
+            (6, 5) => (2*((Rb + Rc)*Rd + Ra*(Rc + Rd))*Rf)/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (6, 6) => 1 - (2*(Rc*(Rd + Re) + Ra*(Rc + Rd + Re) + Rb*(Rc + Rd + Re))*Rf)/(Ra*(Rd*Re + Rb*(Rc + Rd + Re) + Rd*Rf + Re*Rf + Rc*(Re + Rf)) + Rc*(Re*Rf + Rd*(Re + Rf)) + Rb*(Re*Rf + Rc*(Rd + Rf) + Rd*(Re + Rf)));
+            (i, j) => 10;
+        };
+        matrix(M,N,f) = si.bus(N) <: ro.interleave(N,M) : par(n,N, par(m,M,*(f(m+1,n+1)))) :> si.bus(M);
+    };
+};
 
-t = 1/ma.SR; //sampling rate reference for reactive elements
+//===============================Node Creating Functions==================================
+//========================================================================================
+
+//----------------------`(wd.)genericNode`--------------------------
+// Function for generating an adapted node from another faust function or scattering matrix
+//
+// This function generates a node which is suitable for use in the connection tree structure. 
+// genericNode separates the function that it is passed into upward-going and downward-going waves. 
+//
+// #### Usage
+//
+// ```
+// n1(i) = genericNode(i, scatter, upRes);
+// ```
+//
+// Where:
+//
+// * `i`: index used by model-building functions. Should never be user declared
+// * `scatter` : the function which describes the the node's scattering behavior
+// * `upRes` : the function which describes the node's upward-facing port-resistance
+//
+// Note: 
+// `scatter` must be a function with n inputs, n outputs, and n-1 parameter inputs. 
+//  input/output 1 will be used as the adapted upward-facing port of the node, ports 2 to n will all be downward-facing. 
+//  the first input/output pair is assumed to already be adapted - i.e. the output 1 is not dependent on input 1. 
+//  the parameter inputs will receive the port resistances of the downward-facing ports.
+//
+// `upRes` must be a function with n-1 parameter inputs and 1 output.
+//  the parameter inputs will receive the port resistances of the downward-facing ports.
+//  the output should give the upward-facing port resistance of the node based on the upward-facing port resistances of the 
+//
+//  If used on a leaf element (n=1), the model will automatically introduce a one-sample delay. 
+//  Thus, the output of the node at sample t based on the input, a[t], should be the output one sample ahead, b[t+1]. 
+//  This may require transformation of the output signal. 
+//
+//----------------------------------------------------------
+declare genericNode author "Dirk Roosenburg";
+declare genericNode copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare genericNode license "MIT-style STK-4.3 license";
+genericNode =
+case{
+    (0, scatter, upRes) => down(inputs(scatter))
+    with{
+        down(1) = scatter; //leaf node case
+        down(n) = scatter : !, bus(outputs(scatter)-1); //internal node case
+    };
+    (1, scatter, upRes) => up(inputs(scatter))
+    with{
+        up(1) = _; //leaf node case
+        up(n) = bus(inputs(upRes)), 0 , bus(outputs(scatter)-1) : scatter : _, block(outputs(scatter)-1); //internal node case
+    };
+    (2, scatter, upRes) => upRes;
+}
+with{
+    bus(0) = 0:!;
+    bus(x) = si.bus(x);
+    block(0) = 0:!;
+    block(x) = si.block(x);
+};
+
+
+//----------------------`(wd.)genericNode_Vout`--------------------------
+// Function for generating a terminating/leaf node which gives the voltage across itself as a model output
+//
+// This function generates a node which is suitable for use in the connection tree structure. 
+// It also calculates the voltage across the element and gives it as a model output
+//
+// #### Usage
+//
+// ```
+// n1(i) = genericNode_Vout(i, scatter, upRes);
+// ```
+//
+// Where:
+//
+// * `i`: index used by model-building functions. Should never be user declared
+// * `scatter` : the function which describes the the node's scattering behavior
+// * `upRes` : the function which describes the node's upward-facing port-resistance
+//
+// Note: 
+// `scatter` must be a function with 1 input and 1 output. 
+//  it should give the output from the node based on the incident wave. 
+//  
+//  The model will automatically introduce a one-sample delay to the output of the function
+//  Thus, the output of the node at sample t based on the input, a[t], should be the output one sample ahead, b[t+1]. 
+//  This may require transformation of the output signal. 
+//
+// `upRes` must be a function with no inputs and 1 output.
+//  the output should give the upward-facing port resistance of the node
+//
+//----------------------------------------------------------
+declare genericNode_Vout author "Dirk Roosenburg";
+declare genericNode_Vout copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare genericNode_Vout license "MIT-style STK-4.3 license";
+genericNode_Vout =
+case{
+    (0, scatter, upRes) => _ <: b, voltage
+    with{
+        b(a) = a : scatter;
+        voltage(a) = 1/2*(a + b(a)');
+    };
+    (1, scatter, upRes) => _, !;
+    (2, scatter, upRes) => upRes;
+};
+
+//----------------------`(wd.)genericNode_Iout`--------------------------
+// Function for generating a terminating/leaf node which gives the current through itself as a model output
+//
+// This function generates a node which is suitable for use in the connection tree structure. 
+// It also calculates the current through the element and gives it as a model output
+//
+// #### Usage
+//
+// ```
+// n1(i) = genericNode_Iout(i, scatter, upRes);
+// ```
+//
+// Where:
+//
+// * `i`: index used by model-building functions. Should never be user declared
+// * `scatter` : the function which describes the the node's scattering behavior
+// * `upRes` : the function which describes the node's upward-facing port-resistance
+//
+// Note: 
+// `scatter` must be a function with 1 input and 1 output. 
+//  it should give the output from the node based on the incident wave. 
+//  
+//  The model will automatically introduce a one-sample delay to the output of the function
+//  Thus, the output of the node at sample t based on the input, a[t], should be the output one sample ahead, b[t+1]. 
+//  This may require transformation of the output signal. 
+//
+// `upRes` must be a function with no inputs and 1 output.
+//  the output should give the upward-facing port resistance of the node
+//
+//----------------------------------------------------------
+declare genericNode_Iout author "Dirk Roosenburg";
+declare genericNode_Iout copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare genericNode_Iout license "MIT-style STK-4.3 license";
+genericNode_Iout =
+case{
+    (0, scatter, upRes) => _ <: b, current
+    with{
+        b(a) = a : scatter;
+        current(a) = 1/2/upRes*(a - b(a)');
+    };
+    (1, scatter, upRes) => _, !;
+    (2, scatter, upRes) => upRes;
+};
+
+
+//----------------------`(wd.)u_genericNode`--------------------------
+// Function for generating an unadapted node from another Faust function or scattering matrix
+//
+// This function generates a node which is suitable for use as the root of the connection tree structure. 
+//
+// #### Usage
+//
+// ```
+// n1(i) = u_genericNode(i, scatter);
+// ```
+//
+// Where:
+//
+// * `i`: index used by model-building functions. Should never be user declared
+// * `scatter` : the function which describes the the node's scattering behavior
+//
+// Note: 
+// `scatter` must be a function with n inputs, n outputs, and n parameter inputs. 
+//  each input/output pair will be used as a downward-facing port of the node
+//  the parameter inputs will receive the port resistances of the downward-facing ports.
+//
+//----------------------------------------------------------
+declare u_genericNode author "Dirk Roosenburg";
+declare u_genericNode copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenburg.30@gmail.com>";
+declare u_genericNode license "MIT-style STK-4.3 license";
+u_genericNode =
+case{
+    (0, scatter) => scatter;
+    (1, scatter) => block(inputs(scatter));
+    (2, scatter) => 1234;
+}
+with{
+    block(0) = 0:!;
+    block(x) = si.block(x);
+};
 
 
 //===============================Model Building Functions=================================
@@ -1444,9 +1999,10 @@ t = 1/ma.SR; //sampling rate reference for reactive elements
 
 
 //----------------------`(wd.)builddown`--------------------------
-// Function for building the strucutre for calculating waves travling down the WD connection tree.
+// Function for building the structure for calculating waves traveling down the WD connection tree.
+//
 // It recursively steps through the given tree, parametrizes the adaptors, and builds an algorithm.
-// It is used in conjunction with the buildup() function to create a full structure.
+// It is used in conjunction with the buildup() function to create a model.
 //
 // #### Usage
 //
@@ -1514,7 +2070,8 @@ builddown(A) = A(0);
 
 
 //----------------------`(wd.)buildup`--------------------------
-// Function for building the strucutre for calculating waves travling up the WD connection tree.
+// Function for building the structure for calculating waves traveling up the WD connection tree.
+//
 // It recursively steps through the given tree, parametrizes the adaptors, and builds an algorithm.
 // It is used in conjunction with the builddown() function to create a full structure.
 //
@@ -1594,6 +2151,7 @@ buildup(A) = A(1);
 
 //----------------------`(wd.)getres`--------------------------
 // Function for determining the upward-facing port resistance of a partial WD connection tree.
+//
 // It recursively steps through the given tree, parametrizes the adaptors, and builds and algorithm.
 // It is used by the buildup and builddown functions but is also helpful in testing.
 //
@@ -1618,6 +2176,7 @@ getres(A) = A(2);
 
 //----------------------`(wd.)parres`--------------------------
 // Function for determining the upward-facing port resistance of a partial WD connection tree.
+//
 // It recursively steps through the given tree, parametrizes the adaptors, and builds and algorithm.
 // It is used by the buildup and builddown functions but is also helpful in testing.
 // This function is a parallelized version of getres.
@@ -1642,7 +2201,8 @@ parres(Ap) = getres(Ap);
 
 
 //----------------------`(wd.)buildout`--------------------------
-// Function for creating the output matrix for a WD connection tree.
+// Function for creating the output matrix for a WD model from a WD connection tree.
+//
 // It recursively steps through the given tree and creates an output matrix passing only outputs.
 //
 // #### Usage
@@ -1671,7 +2231,8 @@ with{
 
 
 //----------------------`(wd.)buildtree`--------------------------
-// Function for building the functioning DSP model from a WD connection tree.
+// Function for building the DSP model from a WD connection tree structure.
+//
 // It recursively steps through the given tree, parametrizes the adaptors, and builds the algorithm.
 //
 // #### Usage
@@ -1688,11 +2249,6 @@ declare buildtree copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosenb
 declare buildtree license "MIT-style STK-4.3 license";
 buildtree((A : B)) = builddown(A : B)~buildup(A : B) : buildout(A : B);
 
-
-//TODO
-//add input constructor. currently just performed manually. 
-//this will likely include adding additional param options to adaptors. 
-//add comments in Faust formating
 
 
 /*******************************************************************************


### PR DESCRIPTION
New release of the library. 

Changelog:

Changed library syntax. All adaptor names now follow the form [prefix]_[nodeName]_[suffix]. 
-The only valid prefix for nodes is 'u' denoting an unadapted node, i.e. "u_voltage". 
-Nodes are assumed to be adapted unless otherwise noted.  The suffix denotes the adaptor's output from the model. No suffix denotes no output. 'Vout' denotes a voltage output. 'Iout' denotes a current output. 

Added genericNode functions that transform Faust functions and scattering matrices into nodes suitable for use in the library. See internal documentation for more information on use. 

Fixed typos and improved readability of documentation

Added one R-type node, 'sixportPassive' which appears in many passive EQ circuits. 

Changed internal library declaration of parametric wave type. Now nodes that are dependent on the wave definition have an internal scope declaration of rho. 

Changed internal library declaration of T, the sampling interval. All reactive one-ports now have an internal scope declaration of T. 


