### PR TITLE
Implementation of The Dattorro Reverb Topology

### DIFF
--- a/reverbs.lib
+++ b/reverbs.lib
@@ -509,4 +509,28 @@ with {
     };
 };
 
+
+//-------------------------------`(re.)dattorro_orig`-------------------------------
+// Reverberator based on the Dattorro reverb topology with reverb paramters from the
+// original paper.
+// This implementation does not use modulated delay lengths (excursion).
+//
+// #### Usage
+//
+// ```
+// _,_ : dattorro_orig : _,_
+// ```
+//
+// #### Reference
+//
+// <https://ccrma.stanford.edu/~dattorro/EffectDesignPart1.pdf>
+//------------------------------------------------------------
+
+// Author: Jakob Zerbian
+// License: MIT-style STK-4.3 license
+declare dattorro_orig author "Jakob Zerbian";
+declare dattorro_orig license "MIT-style STK-4.3 license";
+
+dattorro_orig = dattorro_rev(0, 0.9995, 0.75, 0.625, 0.5, 0.7, 0.5, 0.0005);
+
 // end further further contributions section

--- a/reverbs.lib
+++ b/reverbs.lib
@@ -529,9 +529,9 @@ with {
 
 // Author: Jakob Zerbian
 // License: MIT-style STK-4.3 license
-declare dattorro_orig author "Jakob Zerbian";
-declare dattorro_orig license "MIT-style STK-4.3 license";
+declare dattorro_rev_default author "Jakob Zerbian";
+declare dattorro_rev_default license "MIT-style STK-4.3 license";
 
-dattorro_orig = dattorro_rev(0, 0.9995, 0.75, 0.625, 0.5, 0.7, 0.5, 0.0005);
+dattorro_rev_default = dattorro_rev(0, 0.9995, 0.75, 0.625, 0.5, 0.7, 0.5, 0.0005);
 
 // end further further contributions section

--- a/reverbs.lib
+++ b/reverbs.lib
@@ -453,4 +453,54 @@ elsewhere among the libraries.  It is expected that all software will be
 released under LGPL, STK-4.3, MIT, BSD, or a similar FOSS license.
 ************************************************************************/
 
+//===============================Dattorro Reverb============================
+//==========================================================================
+
+//-------------------------------`(re.)dattorro`-------------------------------
+// Reverberator based on the Dattorro reverb topology. This implementation does
+// not use modulated delay lengths (excursion)
+//
+// #### Usage
+//
+// ```
+// _,_ : dattorro(pre_delay, bw, i_diff1, i_diff2, decay, d_diff1, d_diff2, damping) : _,_
+// ```
+//
+// Where:
+//
+// * `pre_delay`: pre-delay in samples (fixed at compile time)
+// * `bw`: band-width filter (pre filtering); (0 - 1)
+// * `i_diff1`: input diffusion factor 1; (0 - 1)
+// * `i_diff2`: input diffusion factor 2;
+// * `decay`: decay rate; (0 - 1); infinite decay = 1.0
+// * `d_diff1`: decay diffusion factor 1; (0 - 1)
+// * `d_diff2`: decay diffusion factor 2;
+// * `damping`: high-frequency damping; no damping = 0.0
+//
+// #### Reference
+//
+// * <https://ccrma.stanford.edu/~dattorro/EffectDesignPart1.pdf>
+//------------------------------------------------------------
+dattorro(pre_delay, bw, i_diff1, i_diff2, decay, d_diff1, d_diff2, damping) = 
+    si.bus(2) : + : *(0.5) : predelay : bw_filter : diffusion_network <: ((si.bus(4) :> _,_) ~ (reverb_network : ro.cross(2)))
+with {
+    //allpass using delay with fixed size
+    allpass_f(t, a) = (+ <: @(t),*(a)) ~ *(-a) : mem,_ : +;
+
+    // input pre-delay and diffusion
+    predelay = @(pre_delay);
+    bw_filter = *(bw) : +~( mem :*(1-bw));
+    diffusion_network = allpass_f(142, i_diff1) : allpass_f(107, i_diff1) : allpass_f(379, i_diff2) : allpass_f(277, i_diff2);
+
+    // reverb loop
+    reverb_network = par(i, 2, block(i)) with {
+        d = (672, 908, 4453, 4217, 1800, 2656, 3720, 3163);
+        block(i) = allpass_f(ba.take(i + 1, d),-d_diff1) : @(ba.take(i + 3, d)) : damp : 
+            allpass_f(ba.take(i + 5, d),d_diff2) : @(ba.take(i + 5, d)) : *(decay)
+        with {
+            damp = *(1-damping) : +~*(damping) : *(decay);
+        };
+    };
+};
+
 // end further further contributions section

--- a/reverbs.lib
+++ b/reverbs.lib
@@ -456,14 +456,14 @@ released under LGPL, STK-4.3, MIT, BSD, or a similar FOSS license.
 //===============================Dattorro Reverb============================
 //==========================================================================
 
-//-------------------------------`(re.)dattorro`-------------------------------
+//-------------------------------`(re.)dattorro_rev`-------------------------------
 // Reverberator based on the Dattorro reverb topology. This implementation does
 // not use modulated delay lengths (excursion)
 //
 // #### Usage
 //
 // ```
-// _,_ : dattorro(pre_delay, bw, i_diff1, i_diff2, decay, d_diff1, d_diff2, damping) : _,_
+// _,_ : dattorro_rev(pre_delay, bw, i_diff1, i_diff2, decay, d_diff1, d_diff2, damping) : _,_
 // ```
 //
 // Where:

--- a/reverbs.lib
+++ b/reverbs.lib
@@ -511,9 +511,10 @@ with {
 
 
 //-------------------------------`(re.)dattorro_orig`-------------------------------
-// Reverberator based on the Dattorro reverb topology with reverb paramters from the
+// Reverberator based on the Dattorro reverb topology with reverb parameters from the
 // original paper.
-// This implementation does not use modulated delay lengths (excursion).
+// This implementation does not use modulated delay lengths (excursion) and
+// uses zero length pre-delay
 //
 // #### Usage
 //

--- a/reverbs.lib
+++ b/reverbs.lib
@@ -479,9 +479,15 @@ released under LGPL, STK-4.3, MIT, BSD, or a similar FOSS license.
 //
 // #### Reference
 //
-// * <https://ccrma.stanford.edu/~dattorro/EffectDesignPart1.pdf>
+// <https://ccrma.stanford.edu/~dattorro/EffectDesignPart1.pdf>
 //------------------------------------------------------------
-dattorro(pre_delay, bw, i_diff1, i_diff2, decay, d_diff1, d_diff2, damping) = 
+
+// Author: Jakob Zerbian
+// License: MIT-style STK-4.3 license
+declare dattorro_rev author "Jakob Zerbian";
+declare dattorro_rev license "MIT-style STK-4.3 license";
+
+dattorro_rev(pre_delay, bw, i_diff1, i_diff2, decay, d_diff1, d_diff2, damping) = 
     si.bus(2) : + : *(0.5) : predelay : bw_filter : diffusion_network <: ((si.bus(4) :> _,_) ~ (reverb_network : ro.cross(2)))
 with {
     //allpass using delay with fixed size


### PR DESCRIPTION
If the faust libraries are open for contributions, I am happy to implemented the Dattorro Reverb Topology, described in [this paper](https://ccrma.stanford.edu/~dattorro/EffectDesignPart1.pdf).
I am not quite sure how the license in this case works, because I simply translated the Dattorro Topology into Faust code, but I am open for any discussion.

I also have some good sounding presets and UI variants of the basic implementation ready, if needed.

Cheers!
Jakob