### PR TITLE
Fixed documentation for stereo phasor

### DIFF
--- a/phaflangers.lib
+++ b/phaflangers.lib
@@ -151,13 +151,12 @@ with {               // depth=0 => direct-signal only
 // #### Phaser
 //
 // ```
-// _ : phaser2_stereo(Notches,phase,width,frqmin,fratio,frqmax,speed,depth,fb,invert) : _
+// _ : phaser2_stereo(Notches,width,frqmin,fratio,frqmax,speed,depth,fb,invert) : _
 // ```
 //
 // Where:
 //
 // * `Notches`: number of spectral notches (MACRO ARGUMENT - not a signal)
-// * `phase`: phase of the oscillator (0-1)
 // * `width`: approximate width of spectral notches in Hz
 // * `frqmin`: approximate minimum frequency of first spectral notch in Hz
 // * `fratio`: ratio of adjacent notch frequencies

--- a/phaflangers.lib
+++ b/phaflangers.lib
@@ -151,7 +151,7 @@ with {               // depth=0 => direct-signal only
 // #### Phaser
 //
 // ```
-// _ : phaser2_stereo(Notches,width,frqmin,fratio,frqmax,speed,depth,fb,invert) : _
+// _,_ : phaser2_stereo(Notches,width,frqmin,fratio,frqmax,speed,depth,fb,invert) : _,_
 // ```
 //
 // Where:


### PR DESCRIPTION
Fixed documentation for `phaser2_stereo` function that `phase` argument is used only for mono version.

From
```faust
_ : phaser2_stereo(Notches,phase,width,frqmin,fratio,frqmax,speed,depth,fb,invert) : _
```
To
```faust
_,_ : phaser2_stereo(Notches,width,frqmin,fratio,frqmax,speed,depth,fb,invert) : _,_
```

Maybe, a typical parameter for `fratio`  is needed. A too-large value (like 200~) causes a feedback glitch and difficult to expect what the parameter means.
