### PR TITLE
wdmodels: fix tiny error in resistive current source

### DIFF
--- a/wdmodels.lib
+++ b/wdmodels.lib
@@ -569,7 +569,7 @@ case {
 
 
 //----------------------`(wd.)resCurrent`--------------------------
-// Unadapted Resistive Current Source.
+// Adapted Resistive Current Source.
 //
 // An adaptor implementing a resistive current source within Wave Digital Filter connection trees.
 //
@@ -603,7 +603,7 @@ declare resCurrent copyright "Copyright (C) 2020 by Dirk Roosenburg <dirk.roosen
 declare resCurrent license "MIT-style STK-4.3 license";
 resCurrent =
 case {
-    (0, R, jin) => !, 2*R^(rho)*jin;
+    (0, R, jin) => !, R^(rho)*jin;
     (1, R, jin) => _; 
     (2, R, jin) => R0
     with {


### PR DESCRIPTION
Unfortunately, the reference equation had a small typo. Going back to the derivation, we can see that the factor of two does not actually need to be there.

As an example, we can make a simple circuit with a resistive current source, resistor, and switch, all in parallel. When the switch is closed, we should expect the current going through the resistor to be equal and opposite to the current coming from the current source, so long as the resistive current source has a sufficiently large resistance. When running this code in Faust, we get an output of -2 amps, rather than -1 amps as we would expect. After making the change shown here, we get the expected result.

```faust
import("stdfaust.lib");

switch_closed = -1;
current_amps = 1.0;

model(in1) = wd.buildtree(tree)
with {
    switch(i) = wd.u_switch(i, switch_closed);
    resistor(i) = wd.resistor_Iout(i, 10000.0);
    current_source(i) = wd.resCurrent(i, 10^9, current_amps);
    tree = switch : wd.series : (resistor, current_source);
};

process = model;
```