### PR TITLE
compressors.lib hardening

### DIFF
--- a/compressors.lib
+++ b/compressors.lib
@@ -102,8 +102,9 @@ with {
   gain_computer(strength,thresh,knee,level) =
     select3((level>(thresh-(knee/2)))+(level>(thresh+(knee/2))),
             0,
-            ((level-thresh+(knee/2)) : pow(2)/(2*knee)),
-            (level-thresh)) : max(0)*-strength;
+            ((level-thresh+(knee/2)) : pow(2)/(2*max(ma.EPSILON,min(knee,(thresh*-2))))),
+            (level-thresh))
+    : max(0)*-strength;
 };
 
 
@@ -374,8 +375,9 @@ RMS_compression_gain_mono(strength,thresh,att,rel,knee,prePost) =
     gain_computer(strength,thresh,knee,level) =
       select3((level>(thresh-(knee/2)))+(level>(thresh+(knee/2))),
               0,
-              ((level-thresh+(knee/2)):pow(2)/(2*knee)),
-              (level-thresh)) : max(0)*-strength;
+              ((level-thresh+(knee/2)) : pow(2)/(2*max(ma.EPSILON,min(knee,(thresh*-2))))),
+              (level-thresh))
+    : max(0)*-strength;
     RMS(time) = ba.slidingRMS(s) with {
       s = ba.sec2samp(time):int:max(1);
     };


### PR DESCRIPTION
Keep the knee parameter in peak_compression_gain_mono and RMS_compression_gain_mono within the range [ma.EPSILON,-2*thresh]
to prevent a divide by 0 and a discontinuity in the computed gain reduction.