### PR TITLE
add 2-way, 3-way, and 4-way Linkwitz-Riley fourth-order crossovers

### DIFF
--- a/filters.lib
+++ b/filters.lib
@@ -2700,6 +2700,129 @@ svf = environment {
 	hs(f,q,g)   = svf(8, f, q, g);
 };
 
+//=========== Linkwitz-Riley 4th-order 2-way, 3-way, and 4-way crossovers =====
+//=============================================================================
+//
+// The Linkwitz-Riley (LR) crossovers are designed to produce a fully-flat
+// magnitude response when their outputs are combined. The 4th-order
+// LR filters (LR4) have a 24dB/octave slope and they are rather popular audio
+// crossovers used in multi-band processing.
+//
+// The LR4 can be constructed by cascading two second-order Butterworth
+// filters. For the second-order Butterworth filters, we will use the SVF
+// filter implemented above by setting the Q-factor to 1.0 / sqrt(2.0).
+// These will be cascaded in pairs to build the LR4 highpass and lowpass.
+// For the phase correction, we will use the 2nd-order Butterworth allpass.
+
+
+//----------`(fi.)lowpassLR4`---------------------------------------------------
+// 4th-order Linkwitz-Riley lowpass.
+//
+// #### Usage
+//
+// ```
+// _ : lowpassLR4(cf) : _
+// ```
+//
+// Where:
+//
+// * `cf` is the lowpass cutoff in Hz.
+//------------------------------------------------------------------------------
+declare lowpassLR4 author "Dario Sanfilippo";
+declare lowpassLR4 copyright
+    "Copyright (C) 2022 Dario Sanfilippo <sanfilippo.dario@gmail.com>";
+declare lowpassLR4 license "MIT-style STK-4.3 license";
+lowpassLR4(cf, x) = x : seq(i, 2, svf.lp(cf, 1.0 / sqrt(2.0));
+
+
+//----------`(fi.)highpassLR4`--------------------------------------------------
+// 4th-order Linkwitz-Riley highpass.
+//
+// #### Usage
+//
+// ```
+// _ : highpassLR4(cf) : _
+// ```
+//
+// Where:
+//
+// * `cf` is the highpass cutoff in Hz.
+//------------------------------------------------------------------------------
+declare highpassLR4 author "Dario Sanfilippo";
+declare highpassLR4 copyright
+    "Copyright (C) 2022 Dario Sanfilippo <sanfilippo.dario@gmail.com>";
+declare highpassLR4 license "MIT-style STK-4.3 license";
+highpassLR4(cf, x) = x : seq(i, 2, svf.hp(cf, 1.0 / sqrt(2.0));
+
+
+//----------`(fi.)crossover2LR4`------------------------------------------------
+// Two-way 4th-order Linkwitz-Riley crossover.
+//
+// #### Usage
+//
+// ```
+// _ : crossover2LR4(cf) : si.bus(2)
+// ```
+//
+// Where:
+//
+// * `cf` is the crossover split cutoff in Hz.
+//------------------------------------------------------------------------------
+declare crossover2LR4 author "Dario Sanfilippo";
+declare crossover2LR4 copyright
+    "Copyright (C) 2022 Dario Sanfilippo <sanfilippo.dario@gmail.com>";
+declare crossover2LR4 license "MIT-style STK-4.3 license";
+crossover2LR4(cf, x) = lowpassLR4(cf, x) , highpassLR4(cf, x);
+
+
+//----------`(fi.)crossover3LR4`------------------------------------------------
+// Three-way 4th-order Linkwitz-Riley crossover.
+//
+// #### Usage
+//
+// ```
+// _ : crossover3LR4(cf1, cf2) : si.bus(3)
+// ```
+//
+// Where:
+//
+// * `cf1` is the crossover lower split cutoff in Hz.
+// * `cf2` is the crossover upper split cutoff in Hz.
+//------------------------------------------------------------------------------
+declare crossover3LR4 author "Dario Sanfilippo";
+declare crossover3LR4 copyright
+    "Copyright (C) 2022 Dario Sanfilippo <sanfilippo.dario@gmail.com>";
+declare crossover3LR4 license "MIT-style STK-4.3 license";
+crossover3LR4(cf1, cf2, x) =
+    crossover2LR4(cf1, x) : svf.ap(cf2, 1.0 / sqrt(2.0)) , crossover2LR4(cf2);
+
+
+//----------`(fi.)crossover4LR4`------------------------------------------------
+// Four-way 4th-order Linkwitz-Riley crossover.
+//
+// #### Usage
+//
+// ```
+// _ : crossover4LR4(cf1, cf2) : si.bus(4)
+// ```
+//
+// Where:
+//
+// * `cf1` is the crossover lower split cutoff in Hz.
+// * `cf2` is the crossover mid split cutoff in Hz.
+// * `cf3` is the crossover upper split cutoff in Hz.
+//------------------------------------------------------------------------------
+declare crossover4LR4 author "Dario Sanfilippo";
+declare crossover4LR4 copyright
+    "Copyright (C) 2022 Dario Sanfilippo <sanfilippo.dario@gmail.com>";
+declare crossover4LR4 license "MIT-style STK-4.3 license";
+crossover4LR4(cf1, cf2, cf3, x) =
+    crossover2LR4(cf2, x) :
+        svf.ap(cf3, 1.0 / sqrt(2.0)) ,
+        svf.ap(cf1, 1.0 / sqrt(2.0)) :
+            crossover2LR4(cf1) ,
+            crossover2LR4(cf3);
+
 
 //============================Averaging Functions==============================
 //=============================================================================


### PR DESCRIPTION
Hello, @orlarey @sletz @josmithiii @rmichon.

I'm digging into multi-band processing lately and I needed a crossover. I've implemented the popular 4th-order Linkwitz-Riley crossovers, which have a neat flat response when summing the outputs back together; I've compared them to the current filter bank that we have in the libraries and it could be a useful contribution.

See the magnitude response of the filter outputs below. The split frequencies for the 2-way, 3-way, and 4-way crossover tests are 1280; 640, 2560; 320, 1280, 5120.

Ciao,
Dario

[xover2.pdf](https://github.com/grame-cncm/faustlibraries/files/7975153/xover2.pdf)
[xover3.pdf](https://github.com/grame-cncm/faustlibraries/files/7975154/xover3.pdf)
[xover4.pdf](https://github.com/grame-cncm/faustlibraries/files/7975156/xover4.pdf)


