### PR TITLE
compressors: leave the GR signal in the dB scale

### DIFF
--- a/compressors.lib
+++ b/compressors.lib
@@ -50,14 +50,14 @@ declare version "0.2";
 //=============================Functions Reference========================================
 //========================================================================================
 
-//--------------------`(co.)peak_compression_gain_mono`-------------------
-// Mono dynamic range compressor gain computer.
-// `peak_compression_gain_mono` is a standard Faust function.
+//--------------------`(co.)peak_compression_gain_mono_db`-------------------
+// Mono dynamic range compressor gain computer with dB output.
+// `peak_compression_gain_mono_db` is a standard Faust function.
 //
 // #### Usage
 //
 // ```
-// _ : peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost) : _
+// _ : peak_compression_gain_mono_db(strength,thresh,att,rel,knee,prePost) : _
 // ```
 //
 // Where:
@@ -91,13 +91,11 @@ declare version "0.2";
 // AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
 //------------------------------------------------------------
 
-declare peak_compression_gain_mono author "Bart Brouns";
-declare peak_compression_gain_mono license "GPLv3";
+declare peak_compression_gain_mono_db author "Bart Brouns";
+declare peak_compression_gain_mono_db license "GPLv3";
 
-// note: si.onePoleSwitching has a bug where if you compile with standard precision,
-// down is 0 and prePost is 1, you go into infinite GR and stay there
-peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost) =
-  abs : ba.bypass1(prePost,si.onePoleSwitching(att,rel)) : ba.linear2db : gain_computer(strength,thresh,knee) : ba.bypass1((prePost !=1),si.onePoleSwitching(rel,att)) : ba.db2linear
+peak_compression_gain_mono_db(strength,thresh,att,rel,knee,prePost) =
+  abs : ba.bypass1(prePost,si.onePoleSwitching(att,rel)) : ba.linear2db : gain_computer(strength,thresh,knee) : ba.bypass1((prePost !=1),si.onePoleSwitching(rel,att))
 with {
   gain_computer(strength,thresh,knee,level) =
     select3((level>(thresh-(knee/2)))+(level>(thresh+(knee/2))),
@@ -108,14 +106,14 @@ with {
 };
 
 
-//--------------------`(co.)peak_compression_gain_N_chan`-------------------
-// N channel dynamic range compressor gain computer.
-// `peak_compression_gain_N_chan` is a standard Faust function.
+//--------------------`(co.)peak_compression_gain_N_chan_db`-------------------
+// N channel dynamic range compressor gain computer with dB output.
+// `peak_compression_gain_N_chan_db` is a standard Faust function.
 //
 // #### Usage
 //
 // ```
-// si.bus(N) : peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) : si.bus(N)
+// si.bus(N) : peak_compression_gain_N_chan_db(strength,thresh,att,rel,knee,prePost,link,N) : si.bus(N)
 // ```
 //
 // Where:
@@ -151,20 +149,20 @@ with {
 // AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
 //------------------------------------------------------------
 
-declare peak_compression_gain_N_chan author "Bart Brouns";
-declare peak_compression_gain_N_chan license "GPLv3";
+declare peak_compression_gain_N_chan_db author "Bart Brouns";
+declare peak_compression_gain_N_chan_db license "GPLv3";
 
 // generalise compression gains for N channels.
 // first we define a mono version:
-peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,1) =
-  peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost);
+peak_compression_gain_N_chan_db(strength,thresh,att,rel,knee,prePost,link,1) =
+  peak_compression_gain_mono_db(strength,thresh,att,rel,knee,prePost);
 
 // The actual N-channels version:
 // Calculate the maximum gain reduction of N channels,
 // and then crossfade between that and each channel's own gain reduction,
 // to link/unlink channels
-peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) =
-  par(i, N, peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost))
+peak_compression_gain_N_chan_db(strength,thresh,att,rel,knee,prePost,link,N) =
+  par(i, N, peak_compression_gain_mono_db(strength,thresh,att,rel,knee,prePost))
   <: (si.bus(N),(ba.parallelMin(N) <: si.bus(N))) : ro.interleave(N,2) : par(i,N,(it.interpolate_linear(link)));
 
 
@@ -218,7 +216,7 @@ declare FFcompressor_N_chan license "GPLv3";
 
 // feed forward compressor
 FFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,meter,N) =
-  si.bus(N) <: (peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N),si.bus(N)) : ro.interleave(N,2) : par(i,N,meter*_);
+  si.bus(N) <: (peak_compression_gain_N_chan_db(strength,thresh,att,rel,knee,prePost,link,N),si.bus(N)) : ro.interleave(N,2) : par(i,N,(meter: ba.db2linear)*_);
 
 //--------------------`(co.)FBcompressor_N_chan`-------------------
 // feed back N channel dynamic range compressor.
@@ -270,7 +268,7 @@ declare FBcompressor_N_chan author "Bart Brouns";
 declare FBcompressor_N_chan license "GPLv3";
 
 FBcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,meter,N) =
-  (peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N),si.bus(N) : (ro.interleave(N,2) : par(i,N,meter*_))) ~ si.bus(N);
+  (peak_compression_gain_N_chan_db(strength,thresh,att,rel,knee,prePost,link,N),si.bus(N) : (ro.interleave(N,2) : par(i,N,(meter: ba.db2linear)*_))) ~ si.bus(N);
 
 //--------------------`(co.)FBFFcompressor_N_chan`-------------------
 // feed forward / feed back N channel dynamic range compressor.
@@ -298,7 +296,7 @@ FBcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,meter,N) =
 // * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
 // * `FBFF`: fade between feed forward (0) and feed back (1) compression.
 // * `meter`: a gain reduction meter. It can be implemented like so:
-// `meter = _<:(_,(ba.linear2db:max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;`
+// `meter = _<:(_,(max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;`
 // * `N`: the number of channels of the compressor
 //
 // It uses a strength parameter instead of the traditional ratio, in order to be able to
@@ -325,14 +323,355 @@ declare FBFFcompressor_N_chan license "GPLv3";
 FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) =
   si.bus(N) <: si.bus(N*2) :
   (
-    ((par(i,2,peak_compression_gain_N_chan(strength*(1+((i ==0)*2)),thresh,att,rel,knee,prePost,link,N)) : ro.interleave(N,2) : par(i,N,it.interpolate_linear(FBFF))),si.bus(N))
-    : (ro.interleave(N,2) : par(i,N,meter*_))
+    ((par(i,2,peak_compression_gain_N_chan_db(strength*(1+((i ==0)*2)),thresh,att,rel,knee,prePost,link,N)) : ro.interleave(N,2) : par(i,N,it.interpolate_linear(FBFF))),si.bus(N))
+    : (ro.interleave(N,2) : par(i,N,(meter: ba.db2linear)*_))
   )
   ~ si.bus(N);
 
 
+//--------------------`(co.)RMS_compression_gain_mono_db`-------------------
+// Mono RMS dynamic range compressor gain computer with dB output.
+// `RMS_compression_gain_mono_db` is a standard Faust function.
+//
+// #### Usage
+//
+// ```
+// _ : RMS_compression_gain_mono_db(strength,thresh,att,rel,knee,prePost) : _
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+//
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in Faust.
+//
+// Sometimes even bigger ratios are useful:
+// for example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+//
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+
+declare RMS_compression_gain_mono_db author "Bart Brouns";
+declare RMS_compression_gain_mono_db license "GPLv3";
+
+RMS_compression_gain_mono_db(strength,thresh,att,rel,knee,prePost) =
+  RMS(rel) : ba.bypass1(prePost,si.onePoleSwitching(att,0)) : ba.linear2db : gain_computer(strength,thresh,knee) : ba.bypass1((prePost !=1),si.onePoleSwitching(0,att))  with {
+  gain_computer(strength,thresh,knee,level) =
+    select3((level>(thresh-(knee/2)))+(level>(thresh+(knee/2))),
+            0,
+            ((level-thresh+(knee/2)) : pow(2)/(2*max(ma.EPSILON,knee))),
+            (level-thresh))
+    : max(0)*-strength;
+  RMS(time) = ba.slidingRMS(s) with {
+    s = ba.sec2samp(time):int:max(1);
+  };
+  };
+
+//--------------------`(co.)RMS_compression_gain_N_chan_db`-------------------
+// RMS N channel dynamic range compressor gain computer with dB output.
+// `RMS_compression_gain_N_chan_db` is a standard Faust function.
+//
+// #### Usage
+//
+// ```
+// si.bus(N) : RMS_compression_gain_N_chan_db(strength,thresh,att,rel,knee,prePost,link,N) : si.bus(N)
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
+// * `N`: the number of channels of the compressor
+//
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in Faust.
+//
+// Sometimes even bigger ratios are useful:
+// for example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+//
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+
+declare RMS_compression_gain_N_chan_db author "Bart Brouns";
+declare RMS_compression_gain_N_chan_db license "GPLv3";
+
+RMS_compression_gain_N_chan_db(strength,thresh,att,rel,knee,prePost,link,1) =
+  RMS_compression_gain_mono_db(strength,thresh,att,rel,knee,prePost);
+
+RMS_compression_gain_N_chan_db(strength,thresh,att,rel,knee,prePost,link,N) =
+  par(i,N,RMS_compression_gain_mono_db(strength,thresh,att,rel,knee,prePost))
+  <: (si.bus(N),(ba.parallelMin(N) <: si.bus(N))) : ro.interleave(N,2) : par(i,N,(it.interpolate_linear(link)));
+
+
+//--------------------`(co.)RMS_FBFFcompressor_N_chan`-------------------
+// RMS feed forward / feed back N channel dynamic range compressor.
+// the feedback part has a much higher strength, so they end up sounding similar
+// `RMS_FBFFcompressor_N_chan` is a standard Faust function.
+//
+// #### Usage
+//
+// ```
+// si.bus(N) : RMS_FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) : si.bus(N)
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
+// * `FBFF`: fade between feed forward (0) and feed back (1) compression.
+// * `meter`: a gain reduction meter. It can be implemented like so:
+// `meter = _<:(_,(max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;`
+// * `N`: the number of channels of the compressor
+//
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in Faust.
+//
+// Sometimes even bigger ratios are useful:
+// for example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+//
+// To save CPU we cheat a bit, in a similar way as in the original libs:
+// instead of crosfading between two sets of gain calculators as above,
+// we take the abs of the audio from both the FF and FB, and crossfade between those,
+// and feed that into one set of gain calculators
+// again the strength is much higher when in FB mode, but implemented differently.
+//
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+
+declare RMS_FBFFcompressor_N_chan author "Bart Brouns";
+declare RMS_FBFFcompressor_N_chan license "GPLv3";
+
+RMS_FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) =
+  si.bus(N) <: si.bus(N*2):
+  (
+    ((ro.interleave(N,2) : par(i,N*2,abs) :par(i,N,it.interpolate_linear(FBFF)) : RMS_compression_gain_N_chan_db(strength*(1+((FBFF*-1)+1)),thresh,att,rel,knee,prePost,link,N)),si.bus(N))
+    : (ro.interleave(N,2) : par(i,N,(meter: ba.db2linear)*_))
+  )
+  ~ si.bus(N);
+
+
+//--------------------`(co.)RMS_FBcompressor_peak_limiter_N_chan`-------------------
+// N channel RMS feed back compressor into peak limiter feeding back into the FB compressor.
+// By combining them this way, they complement each other optimally:
+// the RMS compressor doesn't have to deal with the peaks,
+// and the peak limiter get's spared from the steady state signal.
+// The feedback part has a much higher strength, so they end up sounding similar.
+// `RMS_FBcompressor_peak_limiter_N_chan` is a standard Faust function.
+//
+// #### Usage
+//
+// ```
+// si.bus(N) : RMS_FBcompressor_peak_limiter_N_chan(strength,thresh,threshLim,att,rel,knee,link,meter,meterLim,N) : si.bus(N)
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `threshLim`: dB level threshold above which the brickwall limiter kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// this is also used as the release time of the limiter
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// the limiter uses a knee half this size
+// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
+// * `meter`: compressor gain reduction meter. It can be implemented like so:
+// `meter = _<:(_,(max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;`
+// * `meterLim`: brickwall limiter gain reduction meter. It can be implemented like so:
+// `meterLim = _<:(_,(max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;`
+// * `N`: the number of channels of the compressor
+//
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in Faust.
+//
+// Sometimes even bigger ratios are useful:
+// for example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+//
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+
+declare RMS_FBcompressor_peak_limiter_N_chan author "Bart Brouns";
+declare RMS_FBcompressor_peak_limiter_N_chan license "GPLv3";
+
+RMS_FBcompressor_peak_limiter_N_chan(strength,thresh,threshLim,att,rel,knee,link,meter,meterLim,N) =
+  (((RMS_compression_gain_N_chan_db(strength,thresh,att,rel,knee,0,link,N)),si.bus(N)) : ro.interleave(N,2) : par(i,N,(meter: ba.db2linear)*_) : FFcompressor_N_chan(1,threshLim,0,att:min(rel),knee*0.5,0,link,meterLim: ba.db2linear,N))
+  ~ si.bus(N);
+
+
+//===========================linear gain computer section=================================
+// The gain computer functions in this section have been replaced by a version that outputs dBs,
+// but we retain the linear output version for backward compatibility.
+//========================================================================================
+ //
+ //
+//--------------------`(co.)peak_compression_gain_mono`-------------------
+// Mono dynamic range compressor gain computer with linear output.
+// `peak_compression_gain_mono` is a standard Faust function.
+//
+// #### Usage
+//
+// ```
+// _ : peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost) : _
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+//
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in Faust.
+//
+// Sometimes even bigger ratios are useful:
+// for example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+//
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+
+declare peak_compression_gain_mono author "Bart Brouns";
+declare peak_compression_gain_mono license "GPLv3";
+
+peak_compression_gain_mono(strength,thresh,att,rel,knee,prePost) =
+  peak_compression_gain_mono_db(strength,thresh,att,rel,knee,prePost):ba.db2linear;
+
+//--------------------`(co.)peak_compression_gain_N_chan`-------------------
+// N channel dynamic range compressor gain computer with linear output.
+// `peak_compression_gain_N_chan` is a standard Faust function.
+//
+// #### Usage
+//
+// ```
+// si.bus(N) : peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) : si.bus(N)
+// ```
+//
+// Where:
+//
+// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
+// * `thresh`: dB level threshold above which compression kicks in
+// * `att`: attack time = time constant (sec) when level & compression going up
+// * `rel`: release time = time constant (sec) coming out of compression
+// * `knee`: a gradual increase in gain reduction around the threshold:
+// Below thresh-(knee/2) there is no gain reduction,
+// above thresh+(knee/2) there is the same gain reduction as without a knee,
+// and in between there is a gradual increase in gain reduction.
+// * `prePost`: places the level detector either at the input or after the gain computer;
+// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
+// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
+// * `N`: the number of channels of the compressor
+//
+// It uses a strength parameter instead of the traditional ratio, in order to be able to
+// function as a hard limiter.
+// For that you'd need a ratio of infinity:1, and you cannot express that in Faust.
+//
+// Sometimes even bigger ratios are useful:
+// for example a group recording where one instrument is recorded with both a close microphone and a room microphone,
+// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
+//
+// #### References
+//
+// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
+// * Digital Dynamic Range Compressor Design
+// A Tutorial and Analysis
+// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
+// MICHAEL MASSBERG (michael@massberg.org)
+// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
+//------------------------------------------------------------
+
+declare peak_compression_gain_N_chan author "Bart Brouns";
+declare peak_compression_gain_N_chan license "GPLv3";
+
+// generalise compression gains for N channels.
+// first we define a mono version:
+peak_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) =
+  peak_compression_gain_N_chan_db(strength,thresh,att,rel,knee,prePost,link,N)
+  : par(i, N, ba.db2linear);
+
 //--------------------`(co.)RMS_compression_gain_mono`-------------------
-// Mono RMS dynamic range compressor gain computer.
+// Mono RMS dynamic range compressor gain computer with linear output.
 // `RMS_compression_gain_mono` is a standard Faust function.
 //
 // #### Usage
@@ -376,20 +715,10 @@ declare RMS_compression_gain_mono author "Bart Brouns";
 declare RMS_compression_gain_mono license "GPLv3";
 
 RMS_compression_gain_mono(strength,thresh,att,rel,knee,prePost) =
-  RMS(rel) : ba.bypass1(prePost,si.onePoleSwitching(att,0)) : ba.linear2db : gain_computer(strength,thresh,knee) : ba.bypass1((prePost !=1),si.onePoleSwitching(0,att)) : ba.db2linear with {
-    gain_computer(strength,thresh,knee,level) =
-      select3((level>(thresh-(knee/2)))+(level>(thresh+(knee/2))),
-              0,
-              ((level-thresh+(knee/2)) : pow(2)/(2*max(ma.EPSILON,knee))),
-              (level-thresh))
-    : max(0)*-strength;
-    RMS(time) = ba.slidingRMS(s) with {
-      s = ba.sec2samp(time):int:max(1);
-    };
-  };
+  RMS_compression_gain_mono_db(strength,thresh,att,rel,knee,prePost):ba.db2linear;
 
 //--------------------`(co.)RMS_compression_gain_N_chan`-------------------
-// RMS N channel dynamic range compressor gain computer.
+// RMS N channel dynamic range compressor gain computer with linear output.
 // `RMS_compression_gain_N_chan` is a standard Faust function.
 //
 // #### Usage
@@ -434,138 +763,9 @@ RMS_compression_gain_mono(strength,thresh,att,rel,knee,prePost) =
 declare RMS_compression_gain_N_chan author "Bart Brouns";
 declare RMS_compression_gain_N_chan license "GPLv3";
 
-RMS_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,1) =
-  RMS_compression_gain_mono(strength,thresh,att,rel,knee,prePost);
-
 RMS_compression_gain_N_chan(strength,thresh,att,rel,knee,prePost,link,N) =
-  par(i,N,RMS_compression_gain_mono(strength,thresh,att,rel,knee,prePost))
-  <: (si.bus(N),(ba.parallelMin(N) <: si.bus(N))) : ro.interleave(N,2) : par(i,N,(it.interpolate_linear(link)));
-
-
-//--------------------`(co.)RMS_FBFFcompressor_N_chan`-------------------
-// RMS feed forward / feed back N channel dynamic range compressor.
-// the feedback part has a much higher strength, so they end up sounding similar
-// `RMS_FBFFcompressor_N_chan` is a standard Faust function.
-//
-// #### Usage
-//
-// ```
-// si.bus(N) : RMS_FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) : si.bus(N)
-// ```
-//
-// Where:
-//
-// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
-// * `thresh`: dB level threshold above which compression kicks in
-// * `att`: attack time = time constant (sec) when level & compression going up
-// * `rel`: release time = time constant (sec) coming out of compression
-// * `knee`: a gradual increase in gain reduction around the threshold:
-// Below thresh-(knee/2) there is no gain reduction,
-// above thresh+(knee/2) there is the same gain reduction as without a knee,
-// and in between there is a gradual increase in gain reduction.
-// * `prePost`: places the level detector either at the input or after the gain computer;
-// this turns it from a linear return-to-zero detector into a log  domain return-to-threshold detector
-// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
-// * `FBFF`: fade between feed forward (0) and feed back (1) compression.
-// * `meter`: a gain reduction meter. It can be implemented like so:
-// `meter = _<:(_,(ba.linear2db:max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;`
-// * `N`: the number of channels of the compressor
-//
-// It uses a strength parameter instead of the traditional ratio, in order to be able to
-// function as a hard limiter.
-// For that you'd need a ratio of infinity:1, and you cannot express that in Faust.
-//
-// Sometimes even bigger ratios are useful:
-// for example a group recording where one instrument is recorded with both a close microphone and a room microphone,
-// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
-//
-// To save CPU we cheat a bit, in a similar way as in the original libs:
-// instead of crosfading between two sets of gain calculators as above,
-// we take the abs of the audio from both the FF and FB, and crossfade between those,
-// and feed that into one set of gain calculators
-// again the strength is much higher when in FB mode, but implemented differently.
-//
-// #### References
-//
-// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
-// * Digital Dynamic Range Compressor Design
-// A Tutorial and Analysis
-// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
-// MICHAEL MASSBERG (michael@massberg.org)
-// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
-//------------------------------------------------------------
-
-declare RMS_FBFFcompressor_N_chan author "Bart Brouns";
-declare RMS_FBFFcompressor_N_chan license "GPLv3";
-
-RMS_FBFFcompressor_N_chan(strength,thresh,att,rel,knee,prePost,link,FBFF,meter,N) =
-  si.bus(N) <: si.bus(N*2):
-  (
-    ((ro.interleave(N,2) : par(i,N*2,abs) :par(i,N,it.interpolate_linear(FBFF)) : RMS_compression_gain_N_chan(strength*(1+((FBFF*-1)+1)),thresh,att,rel,knee,prePost,link,N)),si.bus(N))
-    : (ro.interleave(N,2) : par(i,N,meter*_))
-  )
-  ~ si.bus(N);
-
-
-//--------------------`(co.)RMS_FBcompressor_peak_limiter_N_chan`-------------------
-// N channel RMS feed back compressor into peak limiter feeding back into the FB compressor.
-// By combining them this way, they complement each other optimally:
-// the RMS compressor doesn't have to deal with the peaks,
-// and the peak limiter get's spared from the steady state signal.
-// The feedback part has a much higher strength, so they end up sounding similar.
-// `RMS_FBcompressor_peak_limiter_N_chan` is a standard Faust function.
-//
-// #### Usage
-//
-// ```
-// si.bus(N) : RMS_FBcompressor_peak_limiter_N_chan(strength,thresh,threshLim,att,rel,knee,link,meter,meterLim,N) : si.bus(N)
-// ```
-//
-// Where:
-//
-// * `strength`: strength of the compression (0 = no compression, 1 means hard limiting, >1 means over-compression)
-// * `thresh`: dB level threshold above which compression kicks in
-// * `threshLim`: dB level threshold above which the brickwall limiter kicks in
-// * `att`: attack time = time constant (sec) when level & compression going up
-// this is also used as the release time of the limiter
-// * `rel`: release time = time constant (sec) coming out of compression
-// * `knee`: a gradual increase in gain reduction around the threshold:
-// Below thresh-(knee/2) there is no gain reduction,
-// above thresh+(knee/2) there is the same gain reduction as without a knee,
-// and in between there is a gradual increase in gain reduction.
-// the limiter uses a knee half this size
-// * `link`: the amount of linkage between the channels. 0 = each channel is independent, 1 = all channels have the same amount of gain reduction
-// * `meter`: compressor gain reduction meter. It can be implemented like so:
-// `meter = _<:(_,(ba.linear2db:max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;`
-// * `meterLim`: brickwall limiter gain reduction meter. It can be implemented like so:
-// `meter = _<:(_,(ba.linear2db:max(maxGR):meter_group((hbargraph("[1][unit:dB][tooltip: gain reduction in dB]", maxGR, 0))))):attach;`
-// * `N`: the number of channels of the compressor
-//
-// It uses a strength parameter instead of the traditional ratio, in order to be able to
-// function as a hard limiter.
-// For that you'd need a ratio of infinity:1, and you cannot express that in Faust.
-//
-// Sometimes even bigger ratios are useful:
-// for example a group recording where one instrument is recorded with both a close microphone and a room microphone,
-// and the instrument is loud enough in the room mic when playing loud, but you want to boost it when it is playing soft.
-//
-// #### References
-//
-// * <http://en.wikipedia.org/wiki/Dynamic_range_compression>
-// * Digital Dynamic Range Compressor Design
-// A Tutorial and Analysis
-// DIMITRIOS GIANNOULIS (Dimitrios.Giannoulis@eecs.qmul.ac.uk)
-// MICHAEL MASSBERG (michael@massberg.org)
-// AND JOSHUA D. REISS (josh.reiss@eecs.qmul.ac.uk)
-//------------------------------------------------------------
-
-declare RMS_FBcompressor_peak_limiter_N_chan author "Bart Brouns";
-declare RMS_FBcompressor_peak_limiter_N_chan license "GPLv3";
-
-RMS_FBcompressor_peak_limiter_N_chan(strength,thresh,threshLim,att,rel,knee,link,meter,meterLim,N) =
-  (((RMS_compression_gain_N_chan(strength,thresh,att,rel,knee,0,link,N)),si.bus(N)) : ro.interleave(N,2) : par(i,N,meter*_) : FFcompressor_N_chan(1,threshLim,0,att:min(rel),knee*0.5,0,link,meterLim,N))
-  ~ si.bus(N);
-
+  RMS_compression_gain_N_chan_db(strength,thresh,att,rel,knee,prePost,link,N)
+  : par(i, N, ba.db2linear);
 
 //=============================Original versions section=============================
 // The functions in this section are largely superseded by the limiters above, but we


### PR DESCRIPTION
This has 2 advantages:
- the link now works correct, since it crossfades in the dB scale
- less cpu usage when a meter is used,
  because it doesn't have to go back to the dB scale