### PR TITLE
ITU-R BS.1770-4 "K-filter"

### DIFF
--- a/filters.lib
+++ b/filters.lib
@@ -3012,6 +3012,7 @@ avg_t19(period, x) = fi.lpt19(period, x);
 //
 // #### Reference
 // <https://www.itu.int/rec/R-REC-BS.1770>
+// <https://gist.github.com/jkbd/07521a98f7873a2dc3dbe16417930791>
 //-----------------------------------------------------------------------------
 declare itu_r_bs_1770_4_kfilter author "Jakob Dübel";
 declare itu_r_bs_1770_4_kfilter copyright "Copyright (C) 2022 Jakob Dübel";

--- a/filters.lib
+++ b/filters.lib
@@ -4,7 +4,7 @@
 // #### References
 // * <https://github.com/grame-cncm/faustlibraries/blob/master/filters.lib>
 //
-// The Filters library is organized into 19 sections:
+// The Filters library is organized into 22 sections:
 //
 // * [Basic Filters](#basic-filters)
 // * [Comb Filters](#comb-filters)
@@ -27,6 +27,7 @@
 // * [State Variable Filters (SVF)](#state-variable-filters)
 // * [Linkwitz-Riley 4th-order 2-way, 3-way, and 4-way crossovers](#linkwitz-riley-4th-order-2-way-3-way-and-4-way-crossovers)
 // * [Averaging Functions](#averaging-functions)
+// * [Standardized Filters](#standardized-filters)
 //
 //########################################################################################
 
@@ -2979,6 +2980,82 @@ declare avg_t19 license "MIT-style STK-4.3 license";
 avg_t19(period, x) = fi.lpt19(period, x); 
 
 
+//=========================== Standardized Filters ============================
+//=============================================================================
+//
+// This section provides filters that are defined by national or
+// international standards, e.g. for measurement applications.
+
+//----------------------`(fi.)itu_r_bs_1770_4_kfilter`-------------------------
+// The prefilter from Recommendation ITU-R BS.1770-4 for loudness
+// measurement. Also known as "K-filter". The recommendation defines
+// biquad filter coefficients for a fixed sample rate of 48kHz (page
+// 4-5). Here, we construct biquads for arbitrary samplerates.  The
+// resulting filter is normalized, such that the magnitude at 997Hz is
+// unity gain 1.0.
+//
+// Please note, the ITU-recommendation handles the normalization in
+// equation (2) by subtracting 0.691dB, which is not needed with
+// `itu_r_bs_1770_4_kfilter`.
+//
+// One option for future improvement might be, to round those filter
+// coefficients, that are almost equal to one. Second, the maximum
+// magnitude difference at 48kHz between the ITU-defined filter and
+// `itu_r_bs_1770_4_kfilter` is 0.001dB, which obviously could be
+// less.
+//
+// #### Usage
+//
+// ```
+// _ : itu_r_bs_1770_4_kfilter : _
+// ```
+//
+// #### Reference
+// <https://www.itu.int/rec/R-REC-BS.1770>
+//-----------------------------------------------------------------------------
+declare itu_r_bs_1770_4_kfilter author "Jakob Dübel";
+declare itu_r_bs_1770_4_kfilter copyright "Copyright (C) 2022 Jakob Dübel";
+declare itu_r_bs_1770_4_kfilter license "ISC license";
+
+itu_r_bs_1770_4_kfilter = stage1 : stage2 : normalize997Hz
+with {
+  freq2k(f_c) = tan((ma.PI * f_c)/ma.SR);
+
+  stage1 = tf22t(b0,b1,b2,a1,a2)
+  with {
+    f_c = 1681.7632251028442; // Hertz
+    gain = 3.9997778685513232; // Decibel
+    K = freq2k(f_c);
+    V_0 = pow(10, (gain/20.0));
+
+    denominator = 1.0 + sqrt(2.0)*K + K^2;
+    b0 = (V_0 + sqrt((2.0*V_0))*K + K^2) / denominator;
+    b1 = 2.0*(K^2 - V_0) / denominator;
+    b2 = (V_0 - sqrt(2.0*V_0)*K + K^2) / denominator;
+
+    a1 = 2*(K^2 - 1) / denominator;
+    a2 = (1 - sqrt(2.0)*K + K^2) / denominator;
+  };
+
+  stage2 = tf22t(b0,b1,b2,a1,a2)
+  with {
+    f_c = 38.135470876002174; // Hertz
+    Q = 0.5003270373223665;
+    K = freq2k(f_c);
+
+    denominator = (K^2) * Q + K + Q;
+    b0 = Q / denominator;
+    b1 = -2*Q / denominator;
+    b2 = b0;
+
+    a1 = (2*Q * (K^2 - 1)) / denominator;
+    a2 = ((K^2) * Q - K + Q) / denominator;
+  };
+
+  normalize997Hz = *(0.9273671710547968);
+};
+
+
 /*******************************************************************************
 # Licenses
 
@@ -3024,4 +3101,21 @@ PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License along 
 with the GNU C Library; if not, write to the Free Software Foundation, Inc., 
 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+
+--------------------------------------------------------------------------------
+
+## ISC License
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
 *******************************************************************************/


### PR DESCRIPTION
@sletz here we go: I added the K-filter `itu_r_bs_1770_4_kfilter` within a new section "Standardized Filters". You suggested adding the filter over here: https://github.com/trummerschlunk/master_me/issues/16#issuecomment-1214904902.

I think, there are a more standardized filters, that could be added in the future. However, please feel free to move the code, if another section or file would be more appropriate.

Does the code in this pull-request meet all the testing requirements of the FAUST libraries?