### PR TITLE
add smoothq

### DIFF
--- a/signals.lib
+++ b/signals.lib
@@ -274,7 +274,7 @@ declare smoothq licence "STK-4.3";
 smoothq(time, q, tar) = envelope 
     with {
         ratio = pow(q, 5) * 32 : max(0.001);
-        coef = exp((-1 * log((1.0 + ratio) / ratio)) / (ma.SR * time));
+        coef = (ratio / (1 + ratio))^(1 / (ma.SR * time));
         fb(cBase, cTar, cSrc, cDistance, cDir, cY, cOut) = base, tar, src, distance, dir, y, out
             with {
                 trig = cTar != tar;


### PR DESCRIPTION
I have an alternate implementation to consider:

```
smoothq(time, q, tar) = out letrec {
    'src = select2(trig, src, out);
    'b = select2(trig, b, 
        select3(dir,
            (0.0 - ratio) * (1.0 - coef),
            0,
            (1.0 + ratio) * (1.0 - coef)
        )
    );
    'y = select3(dir, 
        select2(trig, max( 0, b + y * coef), 1), // 
        0,
        select2(trig, min( 1, b + y * coef), 0)
    );
    'out = select2(trig,
        select3(dir,
            tar + y * dis, 
            out,
            src + y * dis
        ),
        out
    );
    where 
        trig = tar != tar';
        ratio = pow(q, 5) / 10000 + 0.001;
        coef = exp((-1 * log((1.0 + ratio) / ratio)) / (ma.SR * time));
        dis = abs(tar - src);
        dir = (tar > out) + (tar >= out); // 0=lt 1=eq 2=gt
    };
```