### PR TITLE
add adsr_bias and ahdsr_bias

### DIFF
--- a/envelopes.lib
+++ b/envelopes.lib
@@ -326,14 +326,14 @@ adsr_bias_env = environment
 };
 
 
-//------------------------`(en.)adsr_bias_final`------------------------------
-// ADSR (Attack, Decay, Sustain, Release) envelope generator with
+//------------------------`(en.)adsrf_bias`------------------------------
+// ADSR (Attack, Decay, Sustain, Release, Final) envelope generator with
 // control over bias on each segment, and toggle for legato.
 //
 // #### Usage
 //
 // ```
-// adsr_bias_final(at,dt,sl,rt,final,b_att,b_dec,b_rel,legato,t) : _
+// adsrf_bias(at,dt,sl,rt,final,b_att,b_dec,b_rel,legato,t) : _
 // ```
 //
 // Where:
@@ -350,9 +350,9 @@ adsr_bias_env = environment
 // * `t`: trigger signal (attack is triggered when `t>0`, release is triggered
 // when `t=0`)
 //-------------------------------------------------------------------------------
-declare adsr_bias_final author "Andrew John March and David Braun";
-declare adsr_bias_final licence "STK-4.3";
-adsr_bias_final(att, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate) = adsr_bias_env.adsr_bias(att, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate);
+declare adsrf_bias author "Andrew John March and David Braun";
+declare adsrf_bias licence "STK-4.3";
+adsrf_bias(att, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate) = adsr_bias_env.adsr_bias(att, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate);
 
 
 //------------------------`(en.)adsr_bias`------------------------------
@@ -383,14 +383,14 @@ declare adsr_bias licence "STK-4.3";
 adsr_bias(      att, dec, sus, rel,        bias_att, bias_dec, bias_rel, legato, gate) = adsr_bias_env.adsr_bias(att, dec, sus, rel, 0,     bias_att, bias_dec, bias_rel, legato, gate);
 
 
-//------------------------`(en.)ahdsr_bias_final`---------------------------
-// AHDSR (Attack, Hold, Decay, Sustain, Release) envelope generator
+//------------------------`(en.)ahdsrf_bias`---------------------------
+// AHDSR (Attack, Hold, Decay, Sustain, Release, Final) envelope generator
 // with control over bias on each segment, and toggle for legato.
 //
 // #### Usage
 //
 // ```
-// ahdsr_bias_final(at,ht,dt,sl,rt,final,b_att,b_dec,b_rel,legato,t) : _
+// ahdsrf_bias(at,ht,dt,sl,rt,final,b_att,b_dec,b_rel,legato,t) : _
 // ```
 //
 // Where:
@@ -408,9 +408,9 @@ adsr_bias(      att, dec, sus, rel,        bias_att, bias_dec, bias_rel, legato,
 // * `t`: trigger signal (attack is triggered when `t>0`, release is triggered
 // when `t=0`)
 //---------------------------------------------------------------------
-declare ahdsr_bias_final author "Andrew John March and David Braun";
-declare ahdsr_bias_final licence "STK-4.3";
-ahdsr_bias_final(att, hol, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate) = adsr_bias_env.ahdsr_bias(att, hol, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate);
+declare ahdsrf_bias author "Andrew John March and David Braun";
+declare ahdsrf_bias licence "STK-4.3";
+ahdsrf_bias(att, hol, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate) = adsr_bias_env.ahdsr_bias(att, hol, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate);
 
 
 //------------------------`(en.)ahdsr_bias`---------------------------

--- a/envelopes.lib
+++ b/envelopes.lib
@@ -206,7 +206,156 @@ with {
 };
 
 
-//------------------------`(en.)adsr_bias`---------------------------
+adsr_bias_env = environment
+{
+  // In the functions below, we use the equation `y=bias_curve(b,x)`.
+  // `b`: bias between 0 and 1. Bias of 0.5 results in `y=x`. Bias above 0.5 pulls y upward.
+  // `x`: input between 0 and 1 that needs to be remapped/biased into `y`
+  // `y`: `x` after it has been biased. Note that `(y==0 iff x==0) AND (y==1 iff x==1)`.
+  bias_curve(b,x) = (x / ((((1.0/b) - 2.0)*(1.0 - x))+1.0));
+
+  // d/dx of bias_curve(b,x)
+  bias_curve_d_dx(b, x) = 0-(-1+b)*b/((1-x+b*(-1+2*x))^2);
+
+  // Solve for x in y=bias_curve(b,x)
+  bias_curve_inverse(b,y) = (b-1)*y / (2*b*y-b-y);
+
+  // We don't allow the bias to be too close to 0 or 1 because it leads to slopes too
+  // close to positive or negative infinity.
+  bias_clip = aa.clip(.03, .97);
+
+  adsr_bias(att, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate) = envelope 
+  with {
+    ugate = gate>0;
+
+    fb(_state, _y) = nextState, nextY
+    with {
+      // Legato control
+      onset = ba.impulsify(ugate);
+      state = select2(onset, _state, 0), _state : select2(legato);
+      y = select2(onset, _y, 0), _y : select2(legato);
+
+      // State 0: release
+      // State 1: attack
+      // State 2: decay 
+
+      y_at_release = y : ba.latch(ugate==0);
+
+      // Slope is a y-distance divided by a number of samples
+      att_slope = (1-final) / max(1,(att*ma.SR));
+      dec_slope = 0-(1-sus) / max(1,(dec*ma.SR));
+      rel_slope = 0-(y_at_release-final) / max(1,(rel*ma.SR));
+
+      // Get bias based on the state, then clip for safety.
+      b = bias_rel, bias_att, bias_dec : select3(state) : bias_clip;
+
+      // We will remap from an input domain to [0..1] based on the current state.
+      from1 = ba.if(state==2, sus, final);
+      from2 = ba.if(state==0, y_at_release, 1);
+
+      // Prevent divide-by-zero in it.remap
+      pct = it.remap(from1, from2, 0, 1, y), 0.5 : select2(from1==from2) : bias_curve_inverse(b);
+      
+      slope = rel_slope, att_slope, dec_slope : select3(state) : _*bias_curve_d_dx(b, pct);
+          
+      nextY = y + slope : aa.clip(from1, 1);
+      nextState = select2(ugate,
+        0,
+        select3(state,
+          1,
+          select2(y < 1.0, 2, 1),
+          2
+        )
+      );
+    };
+    envelope = fb ~ (_,_) : !, _;
+  };
+
+  ahdsr_bias(att, hol, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate) = envelope 
+  with {
+    ugate = gate>0;
+
+    fb(_state, _y) = nextState, nextY
+    with {
+      // Legato control
+      onset = ba.impulsify(ugate);
+      state = select2(onset, _state, 0), _state : select2(legato);
+      y = select2(onset, _y, 0), _y : select2(legato);
+
+      // State 0: release
+      // State 1: attack
+      // State 2: hold
+      // State 3: decay 
+
+      y_at_release = y : ba.latch(gate==0);
+
+      // Slope is a y-distance divided by a number of samples
+      att_slope = (1-final) / max(1,(att*ma.SR));
+      hold_slope = ba.if(gate, att_slope, rel_slope);
+      dec_slope = 0-(1-sus) / max(1,(dec*ma.SR));
+      rel_slope = 0-(y_at_release-final) / max(1,(rel*ma.SR));
+
+      // Get bias based on the state, then clip for safety.
+      // Note that for the hold state, we choose a bias of 0.5 (the middle value).
+      b = bias_rel, bias_att, .5, bias_dec : ba.selectn(4, state) : bias_clip;
+
+      from1 = ba.if(state==3, sus, final);
+      from2 = ba.if(state==0, y_at_release, 1);
+
+      // Prevent divide-by-zero in it.remap
+      pct = it.remap(from1, from2, 0, 1, y), 0.5 : select2(from1==from2) : bias_curve_inverse(b);
+      
+      slope = rel_slope, att_slope, hold_slope, dec_slope : ba.selectn(4, state) : _*bias_curve_d_dx(b, pct);
+
+      hold_time = ma.SR * hol;
+      hold_timer = ugate : +~(*(ugate * (state != 1)));
+          
+      nextY = y + slope : aa.clip(from1, 1);
+      nextState = select2(ugate,
+        0,
+        ba.selectn(4, state,
+          1,
+          select2(y < 1.0, 2, 1),
+          select2(hold_timer < hold_time, 3, 2),
+          3
+        )
+      );
+    };
+    envelope = fb ~ (_,_) : !, _;
+  };
+};
+
+
+//------------------------`(en.)adsr_bias_final`------------------------------
+// ADSR (Attack, Decay, Sustain, Release) envelope generator with
+// control over bias on each segment, and toggle for legato.
+//
+// #### Usage
+//
+// ```
+// adsr_bias_final(at,dt,sl,rt,final,b_att,b_dec,b_rel,legato,t) : _
+// ```
+//
+// Where:
+//
+// * `at`: attack time (sec)
+// * `dt`: decay time (sec)
+// * `sl`: sustain level (between 0..1)
+// * `rt`: release time (sec)
+// * `final`: final level (between 0..1) but less than or equal to `sl`
+// * `b_att`: bias during attack (between 0..1) where 0.5 is no bias.
+// * `b_dec`: bias during decay (between 0..1) where 0.5 is no bias.
+// * `b_rel`: bias during release (between 0..1) where 0.5 is no bias.
+// * `legato`: toggle for legato. If disabled, envelopes "re-trigger" from zero.
+// * `t`: trigger signal (attack is triggered when `t>0`, release is triggered
+// when `t=0`)
+//-------------------------------------------------------------------------------
+declare adsr_bias_final author "Andrew John March and David Braun";
+declare adsr_bias_final licence "STK-4.3";
+adsr_bias_final(att, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate) = adsr_bias_env.adsr_bias(att, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate);
+
+
+//------------------------`(en.)adsr_bias`------------------------------
 // ADSR (Attack, Decay, Sustain, Release) envelope generator with
 // control over bias on each segment, and toggle for legato.
 //
@@ -228,77 +377,20 @@ with {
 // * `legato`: toggle for legato. If disabled, envelopes "re-trigger" from zero.
 // * `t`: trigger signal (attack is triggered when `t>0`, release is triggered
 // when `t=0`)
-//-------------------------------------------------------------
+//-------------------------------------------------------------------------------
 declare adsr_bias author "Andrew John March and David Braun";
 declare adsr_bias licence "STK-4.3";
-adsr_bias(att, dec, sus, rel, bias_att, bias_dec, bias_rel, legato, gate) = envelope 
-with {
-  ugate = gate>0;
-
-  // In the functions below, we use the equation `y=bias_curve(b,x)`.
-  // b: bias between 0 and 1. Bias of 0.5 results in `y=x`. Bias above 0.5 pulls y upward.
-  // x: input between 0 and 1 that needs to be remapped/biased into `y`
-  // y: `x` after it has been biased. (y==0 iff x==0) AND (y==1 iff x==1)
-  bias_curve(b,x) = (x / ((((1.0/b) - 2.0)*(1.0 - x))+1.0));
-
-  // d/dx of bias_curve(b,x)
-  bias_curve_d_dx(b, x) = 0-(-1+b)*b/((1-x+b*(-1+2*x))^2);
-
-  // Solve for x in y=bias_curve(b,x)
-  bias_curve_inverse(b,y) = (b-1)*y / (2*b*y-b-y);
-
-  fb(_state, _y) = nextState, nextY
-  with {
-    // Legato control
-    onset = ba.impulsify(ugate);
-    state = select2(onset, _state, 0), _state : select2(legato);
-    y = select2(onset, _y, 0), _y : select2(legato);
-
-    // State 0: release
-    // State 1: attack
-    // State 2: decay 
-
-    y_at_release = y : ba.latch(ugate==0);
-
-    // Slope is a y-distance divided by a number of samples
-    att_slope = 1 / max(1,(att*ma.SR));
-    dec_slope = -(1-sus) / max(1,(dec*ma.SR));
-    rel_slope = -y_at_release / max(1,(rel*ma.SR));
-
-    // Get bias based on the state, then clip for safety.
-    b = bias_rel, bias_att, bias_dec : select3(state) : aa.clip(.03, .97);
-
-    // We will remap from an input domain to [0..1] based on the current state.
-    from1 = ba.if(state==2, sus, 0);
-    from2 = ba.if(state==0, y_at_release, 1);
-
-    // Prevent divide-by-zero in it.remap
-    pct = it.remap(from1, from2, 0, 1, y), 0.5 : select2(from1==from2) : bias_curve_inverse(b);
-    
-    slope = rel_slope, att_slope, dec_slope : select3(state) : _*bias_curve_d_dx(b, pct);
-        
-    nextY = y + slope : aa.clip(from1, 1);
-    nextState = select2(ugate,
-      0,
-      select3(state,
-        1,
-        select2(y < 1.0, 2, 1),
-        2
-      )
-    );
-  };
-  envelope = fb ~ (_,_) : !, _;
-};
+adsr_bias(      att, dec, sus, rel,        bias_att, bias_dec, bias_rel, legato, gate) = adsr_bias_env.adsr_bias(att, dec, sus, rel, 0,     bias_att, bias_dec, bias_rel, legato, gate);
 
 
-//------------------------`(en.)ahdsr_bias`---------------------------
+//------------------------`(en.)ahdsr_bias_final`---------------------------
 // AHDSR (Attack, Hold, Decay, Sustain, Release) envelope generator
 // with control over bias on each segment, and toggle for legato.
 //
 // #### Usage
 //
 // ```
-// ahdsr_bias(at,ht,dt,sl,rt,b_att,b_dec,b_rel,legato,t) : _
+// ahdsr_bias_final(at,ht,dt,sl,rt,final,b_att,b_dec,b_rel,legato,t) : _
 // ```
 //
 // Where:
@@ -308,79 +400,47 @@ with {
 // * `dt`: decay time (sec)
 // * `sl`: sustain level (between 0..1)
 // * `rt`: release time (sec)
+// * `final`: final level (between 0..1) but less than or equal to `sl`
 // * `b_att`: bias during attack (between 0..1) where 0.5 is no bias.
 // * `b_dec`: bias during decay (between 0..1) where 0.5 is no bias.
 // * `b_rel`: bias during release (between 0..1) where 0.5 is no bias.
 // * `legato`: toggle for legato. If disabled, envelopes "re-trigger" from zero.
 // * `t`: trigger signal (attack is triggered when `t>0`, release is triggered
 // when `t=0`)
-//----------------------------------------------------------------
+//---------------------------------------------------------------------
+declare ahdsr_bias_final author "Andrew John March and David Braun";
+declare ahdsr_bias_final licence "STK-4.3";
+ahdsr_bias_final(att, hol, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate) = adsr_bias_env.ahdsr_bias(att, hol, dec, sus, rel, final, bias_att, bias_dec, bias_rel, legato, gate);
+
+
+//------------------------`(en.)ahdsr_bias`---------------------------
+// AHDSR (Attack, Hold, Decay, Sustain, Release) envelope generator
+// with control over bias on each segment, and toggle for legato.
+//
+// #### Usage
+//
+// ```
+// ahdsr_bias(at,ht,dt,sl,rt,final,b_att,b_dec,b_rel,legato,t) : _
+// ```
+//
+// Where:
+//
+// * `at`: attack time (sec)
+// * `ht`: hold time (sec)
+// * `dt`: decay time (sec)
+// * `sl`: sustain level (between 0..1)
+// * `rt`: release time (sec)
+// * `final`: final level (between 0..1) but less than or equal to `sl`
+// * `b_att`: bias during attack (between 0..1) where 0.5 is no bias.
+// * `b_dec`: bias during decay (between 0..1) where 0.5 is no bias.
+// * `b_rel`: bias during release (between 0..1) where 0.5 is no bias.
+// * `legato`: toggle for legato. If disabled, envelopes "re-trigger" from zero.
+// * `t`: trigger signal (attack is triggered when `t>0`, release is triggered
+// when `t=0`)
+//---------------------------------------------------------------------
 declare ahdsr_bias author "Andrew John March and David Braun";
 declare ahdsr_bias licence "STK-4.3";
-ahdsr_bias(att, hol, dec, sus, rel, bias_att, bias_dec, bias_rel, legato, gate) = envelope 
-with {
-  ugate = gate>0;
-
-  // In the functions below, we use the equation `y=bias_curve(b,x)`.
-  // b: bias between 0 and 1. Bias of 0.5 results in `y=x`. Bias above 0.5 pulls y upward.
-  // x: input between 0 and 1 that needs to be remapped/biased into `y`
-  // y: `x` after it has been biased. (y==0 iff x==0) AND (y==1 iff x==1)
-  bias_curve(b,x) = (x / ((((1.0/b) - 2.0)*(1.0 - x))+1.0));
-
-  // d/dx of bias_curve(b,x)
-  bias_curve_d_dx(b, x) = 0-(-1+b)*b/((1-x+b*(-1+2*x))^2);
-
-  // Solve for x in y=bias_curve(b,x)
-  bias_curve_inverse(b,y) = (b-1)*y / (2*b*y-b-y);
-
-  fb(_state, _y) = nextState, nextY
-  with {
-    // Legato control
-    onset = ba.impulsify(ugate);
-    state = select2(onset, _state, 0), _state : select2(legato);
-    y = select2(onset, _y, 0), _y : select2(legato);
-
-    // State 0: release
-    // State 1: attack
-    // State 2: hold
-    // State 3: decay 
-
-    y_at_release = y : ba.latch(gate==0);
-
-    // Slope is a y-distance divided by a number of samples
-    att_slope = 1 / max(1,(att*ma.SR));
-    hold_slope = ba.if(gate, att_slope, rel_slope);
-    dec_slope = -(1-sus) / max(1,(dec*ma.SR));
-    rel_slope = -y_at_release / max(1,(rel*ma.SR));
-
-    // Get bias based on the state, then clip for safety.
-    // Note that for the hold state, we choose a bias of 0.5 (the middle value).
-    b = bias_rel, bias_att, .5, bias_dec : ba.selectn(4, state) : aa.clip(.03, .97);
-
-    from1 = ba.if(state==3, sus, 0);
-    from2 = ba.if(state==0, y_at_release, 1);
-
-    // Prevent divide-by-zero in it.remap
-    pct = it.remap(from1, from2, 0, 1, y), 0.5 : select2(from1==from2) : bias_curve_inverse(b);
-    
-    slope = rel_slope, att_slope, hold_slope, dec_slope : ba.selectn(4, state) : _*bias_curve_d_dx(b, pct);
-
-    hold_time = ma.SR * hol;
-    hold_timer = ugate : +~(*(ugate * (state != 1)));
-        
-    nextY = y + slope : aa.clip(from1, 1);
-    nextState = select2(ugate,
-      0,
-      ba.selectn(4, state,
-        1,
-        select2(y < 1.0, 2, 1),
-        select2(hold_timer < hold_time, 3, 2),
-        3
-      )
-    );
-  };
-  envelope = fb ~ (_,_) : !, _;
-};
+ahdsr_bias(      att, hol, dec, sus, rel,        bias_att, bias_dec, bias_rel, legato, gate) = adsr_bias_env.ahdsr_bias(att, hol, dec, sus, rel, 0,     bias_att, bias_dec, bias_rel, legato, gate);
 
 
 //------------------------`(en.)smoothEnvelope`------------------------

--- a/envelopes.lib
+++ b/envelopes.lib
@@ -233,13 +233,20 @@ adsr_bias_env = environment
       // Legato control
       onset = ba.impulsify(ugate);
       state = select2(onset, _state, 0), _state : select2(legato);
-      y = select2(onset, _y, final), _y : select2(legato);
+
+      // two conditions in which we want to hard-reset the `y` to `final`
+      // instead of using the previous `_y`.
+      y = ba.if((onset & (legato<0.5)) | (ba.time==0), final, _y);
+      // note that if final is a constant zero then this could simply be
+      // y = ba.if(onset & (legato<0.5), 0, _y);
 
       // State 0: release
       // State 1: attack
       // State 2: decay 
 
-      y_at_release = y : ba.latch(ugate==0);
+      y_at_release = ba.if(ba.time==0,1,y) : ba.latch(gate==0);
+      // note that if final is a constant zero then this could simply be
+      // y_at_release = y : ba.latch(gate==0);
 
       // Slope is a y-distance divided by a number of samples
       att_slope = (1-final) / max(1,(att*ma.SR));
@@ -280,14 +287,21 @@ adsr_bias_env = environment
       // Legato control
       onset = ba.impulsify(ugate);
       state = select2(onset, _state, 0), _state : select2(legato);
-      y = select2(onset, _y, final), _y : select2(legato);
+
+      // two conditions in which we want to hard-reset the `y` to `final`
+      // instead of using the previous `_y`.
+      y = ba.if((onset & (legato<0.5)) | (ba.time==0), final, _y);
+      // note that if final is a constant zero then this could simply be
+      // y = ba.if(onset & (legato<0.5), 0, _y);
 
       // State 0: release
       // State 1: attack
       // State 2: hold
       // State 3: decay 
 
-      y_at_release = y : ba.latch(gate==0);
+      y_at_release = ba.if(ba.time==0,1,y) : ba.latch(gate==0);
+      // note that if final is a constant zero then this could simply be
+      // y_at_release = y : ba.latch(gate==0);
 
       // Slope is a y-distance divided by a number of samples
       att_slope = (1-final) / max(1,(att*ma.SR));

--- a/envelopes.lib
+++ b/envelopes.lib
@@ -233,7 +233,7 @@ adsr_bias_env = environment
       // Legato control
       onset = ba.impulsify(ugate);
       state = select2(onset, _state, 0), _state : select2(legato);
-      y = select2(onset, _y, 0), _y : select2(legato);
+      y = select2(onset, _y, final), _y : select2(legato);
 
       // State 0: release
       // State 1: attack
@@ -280,7 +280,7 @@ adsr_bias_env = environment
       // Legato control
       onset = ba.impulsify(ugate);
       state = select2(onset, _state, 0), _state : select2(legato);
-      y = select2(onset, _y, 0), _y : select2(legato);
+      y = select2(onset, _y, final), _y : select2(legato);
 
       // State 0: release
       // State 1: attack

--- a/envelopes.lib
+++ b/envelopes.lib
@@ -235,10 +235,10 @@ adsr_bias(att, dec, sus, rel, bias_att, bias_dec, bias_rel, legato, gate) = enve
 with {
   ugate = gate>0;
 
-  // In these functions below
-  // b: bias between 0 and 1. Bias above 0.5 pulls values upward.
+  // In the functions below, we use the equation `y=bias_curve(b,x)`.
+  // b: bias between 0 and 1. Bias of 0.5 results in `y=x`. Bias above 0.5 pulls y upward.
   // x: input between 0 and 1 that needs to be remapped/biased into `y`
-  // y: `x` after it has been biased.
+  // y: `x` after it has been biased. (y==0 iff x==0) AND (y==1 iff x==1)
   bias_curve(b,x) = (x / ((((1.0/b) - 2.0)*(1.0 - x))+1.0));
 
   // d/dx of bias_curve(b,x)
@@ -249,31 +249,33 @@ with {
 
   fb(_state, _y) = nextState, nextY
   with {
-    // legato control
+    // Legato control
     onset = ba.impulsify(ugate);
     state = select2(onset, _state, 0), _state : select2(legato);
     y = select2(onset, _y, 0), _y : select2(legato);
 
-    // state 0: release
-    // state 1: attack
-    // state 2: dec 
+    // State 0: release
+    // State 1: attack
+    // State 2: decay 
 
     y_at_release = y : ba.latch(ugate==0);
 
-    // slope is a y-distance divided by a number of samples
+    // Slope is a y-distance divided by a number of samples
     att_slope = 1 / max(1,(att*ma.SR));
     dec_slope = -(1-sus) / max(1,(dec*ma.SR));
     rel_slope = -y_at_release / max(1,(rel*ma.SR));
 
-    k = bias_rel, bias_att, bias_dec : select3(state) : aa.clip(.03, .97);
+    // Get bias based on the state, then clip for safety.
+    b = bias_rel, bias_att, bias_dec : select3(state) : aa.clip(.03, .97);
 
+    // We will remap from an input domain to [0..1] based on the current state.
     from1 = ba.if(state==2, sus, 0);
     from2 = ba.if(state==0, y_at_release, 1);
 
-    // prevent divide-by-zero in it.remap
-    pct = it.remap(from1, from2, 0, 1, y), 0.5 : select2(from1==from2) : bias_curve_inverse(k);
+    // Prevent divide-by-zero in it.remap
+    pct = it.remap(from1, from2, 0, 1, y), 0.5 : select2(from1==from2) : bias_curve_inverse(b);
     
-    slope = rel_slope, att_slope, dec_slope : select3(state) : _*bias_curve_d_dx(k, pct);
+    slope = rel_slope, att_slope, dec_slope : select3(state) : _*bias_curve_d_dx(b, pct);
         
     nextY = y + slope : aa.clip(from1, 1);
     nextState = select2(ugate,
@@ -319,10 +321,10 @@ ahdsr_bias(att, hol, dec, sus, rel, bias_att, bias_dec, bias_rel, legato, gate) 
 with {
   ugate = gate>0;
 
-  // In these functions below
-  // b: bias between 0 and 1. Bias above 0.5 pulls values upward.
+  // In the functions below, we use the equation `y=bias_curve(b,x)`.
+  // b: bias between 0 and 1. Bias of 0.5 results in `y=x`. Bias above 0.5 pulls y upward.
   // x: input between 0 and 1 that needs to be remapped/biased into `y`
-  // y: `x` after it has been biased.
+  // y: `x` after it has been biased. (y==0 iff x==0) AND (y==1 iff x==1)
   bias_curve(b,x) = (x / ((((1.0/b) - 2.0)*(1.0 - x))+1.0));
 
   // d/dx of bias_curve(b,x)
@@ -333,34 +335,35 @@ with {
 
   fb(_state, _y) = nextState, nextY
   with {
-    // legato control
+    // Legato control
     onset = ba.impulsify(ugate);
     state = select2(onset, _state, 0), _state : select2(legato);
     y = select2(onset, _y, 0), _y : select2(legato);
 
-    // state 0: release
-    // state 1: attack
-    // state 2: hold
-    // state 3: dec 
+    // State 0: release
+    // State 1: attack
+    // State 2: hold
+    // State 3: decay 
 
     y_at_release = y : ba.latch(gate==0);
 
-    // slope is a y-distance divided by a number of samples
+    // Slope is a y-distance divided by a number of samples
     att_slope = 1 / max(1,(att*ma.SR));
     hold_slope = ba.if(gate, att_slope, rel_slope);
     dec_slope = -(1-sus) / max(1,(dec*ma.SR));
     rel_slope = -y_at_release / max(1,(rel*ma.SR));
 
-    // release, attack, hold, decay
-    k = bias_rel, bias_att, .5, bias_dec : ba.selectn(4, state) : aa.clip(.03, .97);
+    // Get bias based on the state, then clip for safety.
+    // Note that for the hold state, we choose a bias of 0.5 (the middle value).
+    b = bias_rel, bias_att, .5, bias_dec : ba.selectn(4, state) : aa.clip(.03, .97);
 
     from1 = ba.if(state==3, sus, 0);
     from2 = ba.if(state==0, y_at_release, 1);
 
-    // prevent divide-by-zero in it.remap
-    pct = it.remap(from1, from2, 0, 1, y), 0.5 : select2(from1==from2) : bias_curve_inverse(k);
+    // Prevent divide-by-zero in it.remap
+    pct = it.remap(from1, from2, 0, 1, y), 0.5 : select2(from1==from2) : bias_curve_inverse(b);
     
-    slope = rel_slope, att_slope, hold_slope, dec_slope : ba.selectn(4, state) : _*bias_curve_d_dx(k, pct);
+    slope = rel_slope, att_slope, hold_slope, dec_slope : ba.selectn(4, state) : _*bias_curve_d_dx(b, pct);
 
     hold_time = ma.SR * hol;
     hold_timer = ugate : +~(*(ugate * (state != 1)));

--- a/envelopes.lib
+++ b/envelopes.lib
@@ -206,6 +206,178 @@ with {
 };
 
 
+//------------------------`(en.)adsr_bias`---------------------------
+// ADSR (Attack, Decay, Sustain, Release) envelope generator with
+// control over bias on each segment, and toggle for legato.
+//
+// #### Usage
+//
+// ```
+// adsr_bias(at,dt,sl,rt,b_att,b_dec,b_rel,legato,t) : _
+// ```
+//
+// Where:
+//
+// * `at`: attack time (sec)
+// * `dt`: decay time (sec)
+// * `sl`: sustain level (between 0..1)
+// * `rt`: release time (sec)
+// * `b_att`: bias during attack (between 0..1) where 0.5 is no bias.
+// * `b_dec`: bias during decay (between 0..1) where 0.5 is no bias.
+// * `b_rel`: bias during release (between 0..1) where 0.5 is no bias.
+// * `legato`: toggle for legato. If disabled, envelopes "re-trigger" from zero.
+// * `t`: trigger signal (attack is triggered when `t>0`, release is triggered
+// when `t=0`)
+//-------------------------------------------------------------
+declare adsr_bias author "Andrew John March and David Braun";
+declare adsr_bias licence "STK-4.3";
+adsr_bias(att, dec, sus, rel, bias_att, bias_dec, bias_rel, legato, gate) = envelope 
+with {
+  ugate = gate>0;
+
+  // In these functions below
+  // b: bias between 0 and 1. Bias above 0.5 pulls values upward.
+  // x: input between 0 and 1 that needs to be remapped/biased into `y`
+  // y: `x` after it has been biased.
+  bias_curve(b,x) = (x / ((((1.0/b) - 2.0)*(1.0 - x))+1.0));
+
+  // d/dx of bias_curve(b,x)
+  bias_curve_d_dx(b, x) = 0-(-1+b)*b/((1-x+b*(-1+2*x))^2);
+
+  // Solve for x in y=bias_curve(b,x)
+  bias_curve_inverse(b,y) = (b-1)*y / (2*b*y-b-y);
+
+  fb(_state, _y) = nextState, nextY
+  with {
+    // legato control
+    onset = ba.impulsify(ugate);
+    state = select2(onset, _state, 0), _state : select2(legato);
+    y = select2(onset, _y, 0), _y : select2(legato);
+
+    // state 0: release
+    // state 1: attack
+    // state 2: dec 
+
+    y_at_release = y : ba.latch(ugate==0);
+
+    // slope is a y-distance divided by a number of samples
+    att_slope = 1. / max(1,(att*ma.SR));
+    dec_slope = -(1.-sus) / max(1,(dec*ma.SR));
+    rel_slope = -y_at_release / max(1,(rel*ma.SR));
+
+    k = bias_rel, bias_att, bias_dec : select3(state) : aa.clip(.03, .97);
+
+    // this looks hacky because it.remap needs safe inputs
+    pct = ba.if(state==2, it.remap(min(.999,sus),1,0,1,y), ba.if(state==0, it.remap(0,max(.001,y_at_release),0,1,y),y)) : bias_curve_inverse(k);
+    
+    slope = rel_slope, att_slope, dec_slope : select3(state) : _*bias_curve_d_dx(k, pct);
+
+    low = 0, 0, sus : select3(state);
+        
+    nextY = y + slope : aa.clip(low, 1.);
+    nextState = select2(ugate,
+      0,
+      select3(state,
+        1,
+        select2(y < 1.0, 2, 1),
+        2
+      )
+    );
+  };
+  envelope = fb ~ (_,_) : !, _;
+};
+
+
+//------------------------`(en.)ahdsr_bias`---------------------------
+// AHDSR (Attack, Hold, Decay, Sustain, Release) envelope generator
+// with control over bias on each segment, and toggle for legato.
+//
+// #### Usage
+//
+// ```
+// ahdsr_bias(at,ht,dt,sl,rt,b_att,b_dec,b_rel,legato,t) : _
+// ```
+//
+// Where:
+//
+// * `at`: attack time (sec)
+// * `ht`: hold time (sec)
+// * `dt`: decay time (sec)
+// * `sl`: sustain level (between 0..1)
+// * `rt`: release time (sec)
+// * `b_att`: bias during attack (between 0..1) where 0.5 is no bias.
+// * `b_dec`: bias during decay (between 0..1) where 0.5 is no bias.
+// * `b_rel`: bias during release (between 0..1) where 0.5 is no bias.
+// * `legato`: toggle for legato. If disabled, envelopes "re-trigger" from zero.
+// * `t`: trigger signal (attack is triggered when `t>0`, release is triggered
+// when `t=0`)
+//----------------------------------------------------------------
+declare ahdsr_bias author "Andrew John March and David Braun";
+declare ahdsr_bias licence "STK-4.3";
+ahdsr_bias(att, hol, dec, sus, rel, bias_att, bias_dec, bias_rel, legato, gate) = envelope 
+with {
+  ugate = gate>0;
+
+  // In these functions below
+  // b: bias between 0 and 1. Bias above 0.5 pulls values upward.
+  // x: input between 0 and 1 that needs to be remapped/biased into `y`
+  // y: `x` after it has been biased.
+  bias_curve(b,x) = (x / ((((1.0/b) - 2.0)*(1.0 - x))+1.0));
+
+  // d/dx of bias_curve(b,x)
+  bias_curve_d_dx(b, x) = 0-(-1+b)*b/((1-x+b*(-1+2*x))^2);
+
+  // Solve for x in y=bias_curve(b,x)
+  bias_curve_inverse(b,y) = (b-1)*y / (2*b*y-b-y);
+
+  fb(_state, _y) = nextState, nextY
+  with {
+    // legato control
+    onset = ba.impulsify(ugate);
+    state = select2(onset, _state, 0), _state : select2(legato);
+    y = select2(onset, _y, 0), _y : select2(legato);
+
+    // state 0: release
+    // state 1: attack
+    // state 2: hold
+    // state 3: dec 
+
+    y_at_release = y : ba.latch(gate==0);
+
+    // slope is a y-distance divided by a number of samples
+    att_slope = 1. / max(1,(att*ma.SR));
+    hold_slope = ba.if(gate, att_slope, rel_slope);
+    dec_slope = -(1.-sus) / max(1,(dec*ma.SR));
+    rel_slope = -y_at_release / max(1,(rel*ma.SR));
+
+    // release, attack, hold, decay
+    k = bias_rel, bias_att, .5, bias_dec : ba.selectn(4, state) : aa.clip(.03, .97);
+
+    // this looks hacky because it.remap needs safe inputs
+    pct = ba.if(state==3, it.remap(min(.999,sus),1,0,1,y), ba.if(state==0, it.remap(0,max(.001,y_at_release),0,1,y),y)) : bias_curve_inverse(k);
+    
+    slope = rel_slope, att_slope, hold_slope, dec_slope : ba.selectn(4, state) : _*bias_curve_d_dx(k, pct);
+
+    low = select2(state==3, 0, sus);
+
+    hold_time = ma.SR * hol;
+    hold_timer = ugate : +~(*(ugate * (state != 1)));
+        
+    nextY = y + slope : aa.clip(low, 1.);
+    nextState = select2(ugate,
+      0,
+      ba.selectn(4, state,
+        1,
+        select2(y < 1.0, 2, 1),
+        select2(hold_timer < hold_time, 3, 2),
+        3
+      )
+    );
+  };
+  envelope = fb ~ (_,_) : !, _;
+};
+
+
 //------------------------`(en.)smoothEnvelope`------------------------
 // An envelope with an exponential attack and release.
 // `smoothEnvelope` is a standard Faust function.

--- a/envelopes.lib
+++ b/envelopes.lib
@@ -267,8 +267,11 @@ with {
 
     k = bias_rel, bias_att, bias_dec : select3(state) : aa.clip(.03, .97);
 
-    // this looks hacky because it.remap needs safe inputs
-    pct = ba.if(state==2, it.remap(min(.999,sus),1,0,1,y), ba.if(state==0, it.remap(0,max(.001,y_at_release),0,1,y),y)) : bias_curve_inverse(k);
+    from1 = ba.if(state==2, sus, 0);
+    from2 = ba.if(state==0, y_at_release, 1);
+
+    // prevent divide-by-zero in it.remap
+    pct = it.remap(from1, from2, 0, 1, y), 0.5 : select2(from1==from2) : bias_curve_inverse(k);
     
     slope = rel_slope, att_slope, dec_slope : select3(state) : _*bias_curve_d_dx(k, pct);
 
@@ -353,8 +356,11 @@ with {
     // release, attack, hold, decay
     k = bias_rel, bias_att, .5, bias_dec : ba.selectn(4, state) : aa.clip(.03, .97);
 
-    // this looks hacky because it.remap needs safe inputs
-    pct = ba.if(state==3, it.remap(min(.999,sus),1,0,1,y), ba.if(state==0, it.remap(0,max(.001,y_at_release),0,1,y),y)) : bias_curve_inverse(k);
+    from1 = ba.if(state==3, sus, 0);
+    from2 = ba.if(state==0, y_at_release, 1);
+
+    // prevent divide-by-zero in it.remap
+    pct = it.remap(from1, from2, 0, 1, y), 0.5 : select2(from1==from2) : bias_curve_inverse(k);
     
     slope = rel_slope, att_slope, hold_slope, dec_slope : ba.selectn(4, state) : _*bias_curve_d_dx(k, pct);
 

--- a/envelopes.lib
+++ b/envelopes.lib
@@ -261,8 +261,8 @@ with {
     y_at_release = y : ba.latch(ugate==0);
 
     // slope is a y-distance divided by a number of samples
-    att_slope = 1. / max(1,(att*ma.SR));
-    dec_slope = -(1.-sus) / max(1,(dec*ma.SR));
+    att_slope = 1 / max(1,(att*ma.SR));
+    dec_slope = -(1-sus) / max(1,(dec*ma.SR));
     rel_slope = -y_at_release / max(1,(rel*ma.SR));
 
     k = bias_rel, bias_att, bias_dec : select3(state) : aa.clip(.03, .97);
@@ -274,10 +274,8 @@ with {
     pct = it.remap(from1, from2, 0, 1, y), 0.5 : select2(from1==from2) : bias_curve_inverse(k);
     
     slope = rel_slope, att_slope, dec_slope : select3(state) : _*bias_curve_d_dx(k, pct);
-
-    low = 0, 0, sus : select3(state);
         
-    nextY = y + slope : aa.clip(low, 1.);
+    nextY = y + slope : aa.clip(from1, 1);
     nextState = select2(ugate,
       0,
       select3(state,
@@ -348,9 +346,9 @@ with {
     y_at_release = y : ba.latch(gate==0);
 
     // slope is a y-distance divided by a number of samples
-    att_slope = 1. / max(1,(att*ma.SR));
+    att_slope = 1 / max(1,(att*ma.SR));
     hold_slope = ba.if(gate, att_slope, rel_slope);
-    dec_slope = -(1.-sus) / max(1,(dec*ma.SR));
+    dec_slope = -(1-sus) / max(1,(dec*ma.SR));
     rel_slope = -y_at_release / max(1,(rel*ma.SR));
 
     // release, attack, hold, decay
@@ -364,12 +362,10 @@ with {
     
     slope = rel_slope, att_slope, hold_slope, dec_slope : ba.selectn(4, state) : _*bias_curve_d_dx(k, pct);
 
-    low = select2(state==3, 0, sus);
-
     hold_time = ma.SR * hol;
     hold_timer = ugate : +~(*(ugate * (state != 1)));
         
-    nextY = y + slope : aa.clip(low, 1.);
+    nextY = y + slope : aa.clip(from1, 1);
     nextState = select2(ugate,
       0,
       ba.selectn(4, state,

--- a/envelopes.lib
+++ b/envelopes.lib
@@ -243,8 +243,8 @@ adsr_bias_env = environment
 
       // Slope is a y-distance divided by a number of samples
       att_slope = (1-final) / max(1,(att*ma.SR));
-      dec_slope = 0-(1-sus) / max(1,(dec*ma.SR));
-      rel_slope = 0-(y_at_release-final) / max(1,(rel*ma.SR));
+      dec_slope = (sus-1) / max(1,(dec*ma.SR));
+      rel_slope = (final-y_at_release) / max(1,(rel*ma.SR));
 
       // Get bias based on the state, then clip for safety.
       b = bias_rel, bias_att, bias_dec : select3(state) : bias_clip;
@@ -292,8 +292,8 @@ adsr_bias_env = environment
       // Slope is a y-distance divided by a number of samples
       att_slope = (1-final) / max(1,(att*ma.SR));
       hold_slope = ba.if(gate, att_slope, rel_slope);
-      dec_slope = 0-(1-sus) / max(1,(dec*ma.SR));
-      rel_slope = 0-(y_at_release-final) / max(1,(rel*ma.SR));
+      dec_slope = (sus-1) / max(1,(dec*ma.SR));
+      rel_slope = (final-y_at_release) / max(1,(rel*ma.SR));
 
       // Get bias based on the state, then clip for safety.
       // Note that for the hold state, we choose a bias of 0.5 (the middle value).


### PR DESCRIPTION
This adds two new functions `adsr_bias` and `ahdsr_bias`.

Each function has three arguments to control the "bias" of the attack, decay, and release segments. This is implemented by using the derivative of a specific [bias function](https://blog.demofox.org/2012/09/24/bias-and-gain-are-your-friend/): For every new sample of audio, we calculate a desired slope and add it to the state. Because this is a discrete method, the curves don't hit their target at the exact target time, but it's quite good. For example there are high errors if the bias is high in the decay or release (see graphs below).

This method is advantageous over https://github.com/grame-cncm/faustlibraries/pull/159 because the bias can bend the curve either up or down whereas that PR just allows pulling it up.

There is also a toggle for legato. If legato is on, then on re-trigger, the envelope is resumed wherever it left off. If legato is off, then the envelope always starts at zero.

Here are some images demonstrating usage of the functions. In the `adsr_bias` graphs, the settings are:
attack: 1
decay: .5
sustain: varies
release: 0.5
note length: varies

In the `ahdsr_bias` graphs, the settings are:
attack: 0.5
decay: .5
sustain: varies
release: 0.5
note length: varies
![Unknown-0](https://github.com/grame-cncm/faustlibraries/assets/2096055/d66ee77e-cdc6-4506-b222-26774e790d61)
![Unknown-1](https://github.com/grame-cncm/faustlibraries/assets/2096055/ea684c39-32be-47ca-b723-b093c1096742)
![Unknown-2](https://github.com/grame-cncm/faustlibraries/assets/2096055/bd4e3b7d-1514-4d87-9951-b481ad25a00d)
![Unknown-3](https://github.com/grame-cncm/faustlibraries/assets/2096055/77b3655b-1ff1-4bfb-bc99-2f5648e23138)
![Unknown-4](https://github.com/grame-cncm/faustlibraries/assets/2096055/378db635-fe94-4124-961b-373e010fa08e)
![Unknown-5](https://github.com/grame-cncm/faustlibraries/assets/2096055/2baad99e-9812-44db-9b6d-cc4f69ddbb5e)

