### PR TITLE
replace 0.707 with 1/sqrt(2)

### DIFF
--- a/demos.lib
+++ b/demos.lib
@@ -58,7 +58,7 @@ re = library("reverbs.lib");
 en = library("envelopes.lib");
 
 declare name "Faust Demos Library";
-declare version "1.1.0";
+declare version "1.1.1";
 
 //########################################################################################
 /************************************************************************
@@ -946,9 +946,9 @@ declare jprev_demo license "GPL2+";
 jprev_demo = re.jpverb(t60, damp, size, early_diff, mod_depth, mod_freq, low, mid, high, low_cutoff, high_cutoff)
 with {
     rev_group(x) = vgroup("[0] JPrev",x);
-    
+    invSqrt2 = 1/sqrt(2);
     mix_group(x) = rev_group(hgroup("[0] Mix",x));
-    early_diff = mix_group(hslider("[1]earlyDiff [style:knob]", 0.707, 0, 0.990, 0.001));
+    early_diff = mix_group(hslider("[1]earlyDiff [style:knob]", invSqrt2, 0, 0.990, 0.001));
     size = mix_group(hslider("[2]size [style:knob]", 1, 0.5, 3, 0.01));
     t60 = mix_group(hslider("[3]t60 [style:knob]", 1, 0.1, 60, 0.1));
     damp = mix_group(hslider("[4]damp [style:knob]", 0, 0, 0.999, 0.0001));

--- a/reverbs.lib
+++ b/reverbs.lib
@@ -14,7 +14,7 @@ fi = library("filters.lib");
 os = library("oscillators.lib");
 
 declare name "Faust Reverb Library";
-declare version "1.2.0";
+declare version "1.2.1";
 
 //########################################################################################
 /************************************************************************
@@ -569,6 +569,7 @@ jp_gh_rev = environment {
 
     smooth_init(s,default) = *(1.0 - s) : + ~ (+(default*init(1)):*(s)) with { init(value) = value - value'; };
 
+    invSqrt2 = 1/sqrt(2);
     jpverb(t60, damp, size, early_diff, mod_depth, mod_freq, low, mid, high, low_cutoff, high_cutoff)
         = ((si.bus(4) :> (de.fdelay4(512, depth + depth*os.oscrs(mod_freq) + 5),de.fdelay4(512, depth + depth*os.oscrc(mod_freq) + 5))
             : par(i,2,si.smooth(damp))
@@ -576,11 +577,11 @@ jp_gh_rev = environment {
             : diffuser(ma.PI/4,early_diff,215,85,size)
             : diffuser(ma.PI/4,early_diff,115,190,size)
             : diffuser(ma.PI/4,early_diff,175,145,size)
-        )~(seq(i,5,diffuser(ma.PI/4,0.707,10+30*i,110+30*i,size))
+        )~(seq(i,5,diffuser(ma.PI/4,invSqrt2,10+30*i,110+30*i,size))
             : par(i,2,de.fdelay4(512, depth + (-1^i)*depth*os.oscrc(mod_freq)+5)
             : de.fdelay1a(8192,(prime_delays(size*(54+150*i))
             : smooth_init(0.995,prime_delays(size*(54+150*i)))) -1))
-            : seq(i,5,diffuser(ma.PI/4,0.707,125+30*i,25+30*i,size))
+            : seq(i,5,diffuser(ma.PI/4,invSqrt2,125+30*i,25+30*i,size))
             : par(i,2,de.fdelay4(8192, depth + (-1^i)*depth*os.oscrs(mod_freq)+5)
             : de.fdelay1a(8192,(prime_delays(size*(134-100*i))
             : smooth_init(0.995,prime_delays(size*(134-100*i)))) -1))

--- a/vaeffects.lib
+++ b/vaeffects.lib
@@ -12,7 +12,7 @@ fi = library("filters.lib");
 ef = library("misceffects.lib");
 
 declare name "Faust Virtual Analog Filter Effect Library";
-declare version "1.2.0";
+declare version "1.2.1";
 
 //########################################################################################
 /************************************************************************
@@ -162,9 +162,10 @@ with {
                             v4 + lp4 , // define s4
                             lp4 // system output
         with {
+            invSqrt2 = 1/sqrt(2);
             T = 1.0 / ma.SR;
             cf = normFreq * .5 * ma.SR;
-            k = 4.0 * (Q - 0.707) / (25.0 - 0.707);
+            k = 4.0 * (Q - invSqrt2) / (25.0 - invSqrt2);
             omegaWarp = tan(ma.PI * cf * T);
             g = omegaWarp / (1.0 + omegaWarp);
             G = g * g * g * g; // ladder's G in generalised form y = G * xi + S
@@ -217,8 +218,9 @@ letrec{
   'y = -(s3*B3*k):-(s2*B2*k):-(s1*B1*k):*(alpha0):-(s1):*(alpha):+(s1):-(s2):*(alpha):+(s2) <:_*-1,((-(s3):*(alpha):+(s3))*2):>_;
 }
 with{
+  invSqrt2 = 1/sqrt(2);
   freq = 2*(10^(3*normFreq+1));
-  k = 2.0*(Q - 0.707)/(25.0 - 0.707);
+  k = 2.0*(Q - invSqrt2)/(25.0 - invSqrt2);
   wd = 2*ma.PI*freq;
   T = 1/ma.SR;
   wa = (2/T)*tan(wd*T/2);
@@ -328,7 +330,8 @@ letrec{
 }
 with{
   freq = 2*(10^(3*normFreq+1));
-  k = (17 - (normFreq^10)*9.7)*(Q - 0.707)/(25.0 - 0.707);
+  invSqrt2 = 1/sqrt(2);
+  k = (17 - (normFreq^10)*9.7)*(Q - invSqrt2)/(25.0 - invSqrt2);
   wd = 2*ma.PI*freq;
   T = 1/ma.SR;
   wa = (2/T)*tan(wd*T/2);
@@ -403,8 +406,9 @@ letrec{
   'y = _-s1:_*alpha:_+s1:_+(s3*B3):_+(s2*B2) :_*alpha0:_-s3:_*alpha:_+s3;
 }
 with{
+  invSqrt2 = 1/sqrt(2);
   freq = 2*(10^(3*normFreq+1));
-  K = 2.0*(Q - 0.707)/(10.0 - 0.707);
+  K = 2.0*(Q - invSqrt2)/(10.0 - invSqrt2);
   wd = 2*ma.PI*freq;
   T = 1/ma.SR;
   wa = (2/T)*tan(wd*T/2);
@@ -442,8 +446,9 @@ letrec{
   'y = _<:(_-s1:_*alpha:_+s1)*-1,_:>_+(s3*B3):_+(s2*B2):_*alpha0;
 }
 with{
+  invSqrt2 = 1/sqrt(2);
   freq = 2*(10^(3*normFreq+1));
-  K = 2.0*(Q - 0.707)/(10.0 - 0.707);
+  K = 2.0*(Q - invSqrt2)/(10.0 - invSqrt2);
   wd = 2*ma.PI*freq;
   T = 1/ma.SR;
   wa = (2/T)*tan(wd*T/2);


### PR DESCRIPTION
I replaced 0.707 with 1/sqrt(2) which is more precise. I also hope that a language model looking at the trees of Faust source code would learn better from the procedural way rather than the hard-coded way. In general, I think that if a constant can be replaced with an expression it should. It's the same reason we should always use ma.PI instead of 3.14.