### PR TITLE
Stereo widener

### DIFF
--- a/misceffects.lib
+++ b/misceffects.lib
@@ -363,7 +363,7 @@ declare piano_dispersion_filter license "STK-4.3";
 //
 // * `w`: stereo width between 0 and 1
 //
-// At `w=0`, the output signal is mono ((left+right)/2 in both channels).
+// At `w=0`, the output signal is mono ((left+right) in both channels).
 // At `w=1`, there is no effect (original stereo image).
 // Thus, w between 0 and 1 varies stereo width from 0 to "original".
 //

--- a/misceffects.lib
+++ b/misceffects.lib
@@ -59,7 +59,7 @@ aa = library("aanl.lib");
 ef = library("misceffects.lib"); // for compatible copy/paste out of this file
 
 declare name "Misc Effects Library";
-declare version "2.4.0"; 
+declare version "2.4.1"; 
 
 //======================================Dynamic===========================================
 //========================================================================================
@@ -381,6 +381,41 @@ with {
 
 declare stereo_width author "Julius O. Smith III";
 declare stereo_width license "STK-4.3";
+
+//-------------------------`(ef.)stereo_widener`---------------------------
+// Stereo Width effect that can widen beyond the source's original
+// stereo image.
+//
+// #### Usage
+//
+// ```
+// _,_ : stereo_widener(w) : _,_
+// ```
+//
+// Where:
+//
+// * `w`: stereo width between 0 and 1.
+//
+// At `w=0`, the output signal is mono ((L+R) in both channels).
+// At `w=.5`, there is no effect (original stereo image).
+// At `w=1`, the output signal is (L-R), (R-L) and retains only the input's "side".
+// Note that if the input is mono and `w=1`, then the output will be silent.
+//
+// #### Reference
+//
+// <https://www.kvraudio.com/forum/viewtopic.php?p=2838482#p2838482>
+//
+//------------------------------------------------------------
+stereo_widener(w) = invSqrt2 : shuffle : *(midGain),*(stereoGain) : shuffle : invSqrt2
+with {
+    invSqrt2 = _/sqrt(2), _/sqrt(2);
+    shuffle = _,_ <: +,-;
+    midGain = 2*(1-w);
+    stereoGain = 2*w;
+};
+
+declare stereo_widener author "David Braun";
+declare stereo_widener license "STK-4.3";
 
 //===========================================Meshes=======================================
 //========================================================================================


### PR DESCRIPTION
This allows us to exaggerate the stereoness of an input. Beware it can result in silence if the original input has no stereoness to begin with.

```faust
import("stdfaust.lib");

stereo_widener(w) = invSqrt2 : shuffle : *(midGain),*(stereoGain) : shuffle : invSqrt2
with {
    invSqrt2 = _/sqrt(2), _/sqrt(2);
    shuffle = _,_ <: +,-;
    midGain = 2*(1-w);
    stereoGain = 2*w;
};

width = hslider("width", 0.5, 0., 1., .001);
// drag a stereo input into the IDE and try these out:

// normal usage:
// process = _,_ : ef.stereo_width(width);
process = _,_ : stereo_widener(width);

// pretend left input is silence:
// `w=0` is NOT silence, and `w=1` is NOT silence.
// process = _,_ : 0*_,_ : stereo_widener(width);

// pretend input is mono:
// `w=1` is silence.
// process = _,_ :> _*.5 <: stereo_widener(width);

// process(L,R) = (L+R) <: _, _; // same when `w=0`
// process = _, _; // same when `w=0.5`
// process(L,R) = (L-R), (R-L); // same when `w=1`
```