### PR TITLE
add ba.tAndH() and fix ma.zc()

### DIFF
--- a/basics.lib
+++ b/basics.lib
@@ -448,7 +448,7 @@ sweep = %(int(*:max(1)))~+(1);
 // time : _
 // ```
 //------------------------
-time = (+(1)~_) - 1;
+time = +(1)~_ : mem;
 
 
 //-------`(ba.)ramp`----------
@@ -1777,8 +1777,22 @@ latch(trig, x) = x * s : + ~ *(1-s) with { s = (trig' <= 0) & (trig > 0); };
 //----------------------------------------------------------------
 declare sAndH author "Romain Michon";
 
-sAndH(trig) = select2(trig,_,_) ~ _;
+sAndH(trig) = select2(trig) ~ _;
 
+//--------------------------`(ba.)tAndH`-------------------------------
+// Test And Hold: "records" the input when pred(input) is true, outputs a frozen value otherwise.
+//
+// #### Usage
+//
+// ```
+// _ : tAndH(pred) : _
+// ```
+//
+// Where:
+//
+// * `pred`: predicate to test the input
+//----------------------------------------------------------------
+tAndH(pred) = _ <: pred,_ : sAndH;
 
 //--------------------------`(ba.)downSample`-------------------------------
 // Down sample a signal. WARNING: this function doesn't change the

--- a/maths.lib
+++ b/maths.lib
@@ -50,6 +50,7 @@ closed source license or any other license if you decide so.
 ************************************************************************/
 
 // This library contains platform specific constants 
+ba = library("basics.lib");
 pl = library("platform.lib");
 ma = library("maths.lib"); // for compatible copy/paste out of this file
 
@@ -794,5 +795,4 @@ nextpow2(x) = ceil(log(x)/log(2.0));
 // _ : zc : _
 // ```
 //-----------------------------------------------------------------------------
-zc(x) = x * x' < 0;
-
+zc = ba.tAndH(!=(0)) <: *(mem) < 0;


### PR DESCRIPTION
ma.zc() is wrong in that it can't detect the crossing if the input signal is zero in between, for example

	process = os.oscrs(F) : *(abs > 1/2) : ma.zc;

will never output 1.

The new function ba.tAndH() looks useful on its own, for example we can do

	zc_threshold(t) = ba.tAndH(abs >= t) <: *(mem) < 0;

which reports the "significant" changes from -t to +t or vice versa.

While at it, change ba.time() to eliminate the unnecessary -(1) and generate a slightly better code.