### PR TITLE
add ba.selectbus

### DIFF
--- a/basics.lib
+++ b/basics.lib
@@ -58,7 +58,7 @@ it = library("interpolators.lib");
 si = library("signals.lib");
 
 declare name "Faust Basic Element Library";
-declare version "1.17.1";
+declare version "1.18.0";
 
 //=============================Conversion Tools===========================================
 //========================================================================================
@@ -1696,6 +1696,29 @@ with {
         left  = n-right;
     };
 };
+
+
+//----------------------(ba.)selectbus-----------------------------------------
+// Select a bus among `NUM_BUSES` buses, where each bus has `BUS_SIZE` outputs.
+// The order of the signal inputs should be the signals of the first bus, the
+// signals of the second bus, and so on.
+//
+// #### Usage
+//
+// ```
+// process = si.bus(BUS_SIZE*NUM_BUSES) : selectbus(BUS_SIZE, NUM_BUSES, i) : si.bus(BUS_SIZE);
+// ```
+//
+// Where:
+//
+// * `BUS_SIZE`: The number of outputs from each bus (int, known at compile time).
+// * `NUM_BUSES`: The number of buses (int, known at compile time).
+// * `i`: The index of the bus to select (int, `0<=i<NUM_BUSES`)
+//
+//-------------------------------------------------------------------
+selectbus(BUS_SIZE, NUM_BUSES, i) = ro.interleave(BUS_SIZE, NUM_BUSES) : par(j, BUS_SIZE, selectn(NUM_BUSES, i));
+declare selectbus author "David Braun";
+declare selectbus license "MIT";
 
 
 //-----------------------------`(ba.)selectmulti`---------------------------------


### PR DESCRIPTION
Select a bus among `NUM_BUSES` buses, where each bus has `BUS_SIZE` outputs. The order of the signal inputs should be the signals of the first bus, the signals of the second bus, and so on.

I thought that there was a need for a variation of `ba.selectmulti` where the crossfade is zero and the "circuits" are many signals from many buses.

Example program:
```faust
import("stdfaust.lib");
selectbus(BUS_SIZE, NUM_BUSES, i) = ro.interleave(BUS_SIZE, NUM_BUSES) : par(j, BUS_SIZE, ba.selectn(NUM_BUSES, i));

BUS_SIZE = 3;
NUM_BUSES = 4;

i = nentry("i", 0, 0, NUM_BUSES-1, 1);
process = si.bus(BUS_SIZE*NUM_BUSES) : selectbus(BUS_SIZE, NUM_BUSES, i);
```