### PR TITLE
add selectxbus (selectbus with crossfade)

### DIFF
--- a/basics.lib
+++ b/basics.lib
@@ -1721,6 +1721,36 @@ declare selectbus author "David Braun";
 declare selectbus license "MIT";
 
 
+//----------------------`(ba.)selectxbus`-----------------------------------------
+// Like (ba.)selectbus, but with a cross-fade when selecting the bus
+// using the same technique than (ba.)selectmulti
+//
+// #### Usage
+//
+// ```
+// process = si.bus(BUS_SIZE*NUM_BUSES) : selectbus(BUS_SIZE, NUM_BUSES, FADE, id) : si.bus(BUS_SIZE);
+// ```
+//
+// Where:
+//
+// * `BUS_SIZE`: The number of outputs from each bus (int, known at compile time).
+// * `NUM_BUSES`: The number of buses (int, known at compile time).
+// * `FADE`:  The number of samples for the crossfade.
+// * `id`: The index of the bus to select (int, `0<=id<NUM_BUSES`)
+//
+//-------------------------------------------------------------------
+selectxbus(BUS_SIZE, NUM_BUSES, FADE, id) =
+    ro.interleave(BUS_SIZE, NUM_BUSES):
+    par(i, BUS_SIZE, selectnX(NUM_BUSES, id, xfade))
+    with {
+        xfade(i, j, x, y) = x*(1-xb) + y*xb with {
+            xb = ramp(FADE, (i >= j));
+        };
+    };
+declare selectxbus author "Marc Lavallée";
+declare selectxbus license "MIT";
+
+
 //-----------------------------`(ba.)selectmulti`---------------------------------
 // Selects the ith circuit among N at run time (all should have the same number of inputs and outputs)
 // with a crossfade.


### PR DESCRIPTION
I was looking for an alternative to the ABComparaison plugin (by Danial Rudrich) and found the new selectbus function then made a version with crossfade using code from selectmulti. The name of this augmented version could be different, or it could even replace selectbus (if the overhead of computing the crossfade is not too high). This is a  draft pull request, so please let me know!

Here's some demo code:

```
import("stdfaust.lib");

bus_size = 2;
num_buses = 3;
xfade = hslider("Xfade (sec)", 0.1, 0, 1, 0.1) * ma.SR;
choice = hslider(
	"Bus[style:radio{'A':1;'B':2;'C':3}]",
	1, 1, num_buses, 1) -1;
process = ba.selectxbus(bus_size, num_buses, xfade, choice);


```