### PR TITLE
Fix documentation for os.lf_triangle

### DIFF
--- a/oscillators.lib
+++ b/oscillators.lib
@@ -541,7 +541,7 @@ lf_trianglepos(freq) = 1.0-abs(saw1(freq)); // saw1 defined below
 
 
 //----------`(os.)lf_triangle`----------
-// Positive unit-amplitude LF triangle wave.
+// Zero-mean unit-amplitude LF triangle wave.
 // `lf_triangle` is a standard Faust function.
 //
 // #### Usage


### PR DESCRIPTION
Change documentation from `Positive` to `Zero-Mean` for `os.lf_triangle`, since `os.lf_trianglepos` is the positive function.