### PR TITLE
Updated to mkdocs 1.5.3

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -79,7 +79,7 @@ $(FAUSTDIR):
 
 ####################################################################
 install:
-	pip install mkdocs
+	pip install mkdocs==1.5.3
 	pip install mkdocs-pdf-export-plugin
 	pip install markdown-include
 	pip install mkdocs-bootswatch

--- a/doc/docs/standardFunctions.md
+++ b/doc/docs/standardFunctions.md
@@ -1,6 +1,6 @@
 # Standard Functions
 
-Dozens of functions are implemented in the Faust libraries and many of them are very specialized and not useful to beginners or to people who only need to use Faust for basic applications. This section offers an index organized by categories of the "standard Faust functions" (basic filters, effects, synthesizers, etc.). This index only contains functions without a user interface (UI). Faust functions with a built-in UI can be found in [`demos.lib`](../libs/demos).
+Dozens of functions are implemented in the Faust libraries and many of them are very specialized and not useful to beginners or to people who only need to use Faust for basic applications. This section offers an index organized by categories of the "standard Faust functions" (basic filters, effects, synthesizers, etc.). This index only contains functions without a user interface (UI). Faust functions with a built-in UI can be found in [`demos.lib`]libs/demos.md.md).
 
 
 ## Analysis Tools
@@ -9,8 +9,8 @@ Dozens of functions are implemented in the Faust libraries and many of them are 
 
 Function Type | Function Name | Description
 --- | --- | ---
-[Amplitude Follower](../libs/analyzers/#anamp_follower) | [`an.`](../libs/analyzers)[`amp_follower`](../libs/analyzers/#anamp_follower) | Classic analog audio envelope follower
-[Octave Analyzers](../libs/analyzers/#anmth_octave_analyzer) | [`an.`](../libs/analyzers)[`mth_octave_analyzer[N]`](../libs/analyzers/#anmth_octave_analyzer) | Octave analyzers
+[Amplitude Follower]libs/analyzers.md#anamp_follower.md) | [`an.`]libs/analyzers.md.md)[`amp_follower`]libs/analyzers.md#anamp_follower.md) | Classic analog audio envelope follower
+[Octave Analyzers]libs/analyzers.md#anmth_octave_analyzer.md) | [`an.`]libs/analyzers.md.md)[`mth_octave_analyzer[N]`]libs/analyzers.md#anmth_octave_analyzer.md) | Octave analyzers
 
 <div class="table-end"></div>
 
@@ -21,25 +21,25 @@ Function Type | Function Name | Description
 
 Function Type | Function Name | Description
 --- | --- | ---
-[Beats](../libs/basics/#babeat) | [`ba.`](../libs/basics)[`beat`](../libs/basics/#babeat) | Pulses at a specific tempo
-[Block](../libs/signals/#siblock) | [`si.`](../libs/signals)[`block`](../libs/signals/#siblock) | Terminate n signals
-[Break Point Function](../libs/basics/#babpf) | [`ba.`](../libs/basics)[`bpf`](../libs/basics/#babpf) | Beak Point Function (BPF)
-[Bus](../libs/signals/#sibus) | [`si.`](../libs/signals)[`bus`](../libs/signals/#sibus) | Bus of n signals
-[Bypass (Mono)](../libs/basics/#babypass1) | [`ba.`](../libs/basics)[`bypass1`](../libs/basics/#babypass1) | Mono bypass
-[Bypass (Stereo)](../libs/basics/#babypass2) | [`ba.`](../libs/basics)[`bypass2`](../libs/basics/#babypass2) | Stereo bypass
-[Count Elements](../libs/basics/#bacount) | [`ba.`](../libs/basics)[`count`](../libs/basics/#bacount) | Count elements in a list
-[Count Down](../libs/basics/#bacountdown) | [`ba.`](../libs/basics)[`countdown`](../libs/basics/#bacountdown) | Samples count down
-[Count Up](../libs/basics/#bacountup) | [`ba.`](../libs/basics)[`countup`](../libs/basics/#bacountup) | Samples count up
-[Delay (Integer)](../libs/delays/#dedelay) | [`de.`](../libs/delays)[`delay`](../libs/delays/#dedelay) | Integer delay
-[Delay (Float)](../libs/delays/#defdelay) | [`de.`](../libs/delays)[`fdelay`](../libs/delays/#defdelay) | Fractional delay
-[Down Sample](../libs/basics/#badownsample) | [`ba.`](../libs/basics)[`downSample`](../libs/basics/#badownsample) | Down sample a signal
-[Impulsify](../libs/basics/#baimpulsify) | [`ba.`](../libs/basics)[`impulsify`](../libs/basics/#baimpulsify) | Turns a signal into an impulse
-[Sample and Hold](../libs/basics/#basandh) | [`ba.`](../libs/basics)[`sAndH`](../libs/basics/#basandh) | Sample and hold
-[Signal Crossing](../libs/routes/#rocross) | [`ro.`](../libs/routes)[`cross`](../libs/routes/#rocross) | Cross n signals
-[Smoother (Default)](../libs/signals/#sismoo) | [`si.`](../libs/signals)[`smoo`](../libs/signals/#sismoo) | Exponential smoothing
-[Smoother](../libs/signals/#sismooth) | [`si.`](../libs/signals)[`smooth`](../libs/signals/#sismooth) | Exponential smoothing with controllable pole
-[Take Element](../libs/basics/#batake) | [`ba.`](../libs/basics)[`take`](../libs/basics/#batake) | Take en element from a list
-[Time](../libs/basics/#batime) | [`ba.`](../libs/basics)[`time`](../libs/basics/#batime) | A simple timer
+[Beats]libs/basics.md#babeat.md) | [`ba.`]libs/basics.md.md)[`beat`]libs/basics.md#babeat.md) | Pulses at a specific tempo
+[Block]libs/signals.md#siblock.md) | [`si.`]libs/signals.md.md)[`block`]libs/signals.md#siblock.md) | Terminate n signals
+[Break Point Function]libs/basics.md#babpf.md) | [`ba.`]libs/basics.md.md)[`bpf`]libs/basics.md#babpf.md) | Beak Point Function (BPF)
+[Bus]libs/signals.md#sibus.md) | [`si.`]libs/signals.md.md)[`bus`]libs/signals.md#sibus.md) | Bus of n signals
+[Bypass (Mono)]libs/basics.md#babypass1.md) | [`ba.`]libs/basics.md.md)[`bypass1`]libs/basics.md#babypass1.md) | Mono bypass
+[Bypass (Stereo)]libs/basics.md#babypass2.md) | [`ba.`]libs/basics.md.md)[`bypass2`]libs/basics.md#babypass2.md) | Stereo bypass
+[Count Elements]libs/basics.md#bacount.md) | [`ba.`]libs/basics.md.md)[`count`]libs/basics.md#bacount.md) | Count elements in a list
+[Count Down]libs/basics.md#bacountdown.md) | [`ba.`]libs/basics.md.md)[`countdown`]libs/basics.md#bacountdown.md) | Samples count down
+[Count Up]libs/basics.md#bacountup.md) | [`ba.`]libs/basics.md.md)[`countup`]libs/basics.md#bacountup.md) | Samples count up
+[Delay (Integer)]libs/delays.md#dedelay.md) | [`de.`]libs/delays.md.md)[`delay`]libs/delays.md#dedelay.md) | Integer delay
+[Delay (Float)]libs/delays.md#defdelay.md) | [`de.`]libs/delays.md.md)[`fdelay`]libs/delays.md#defdelay.md) | Fractional delay
+[Down Sample]libs/basics.md#badownsample.md) | [`ba.`]libs/basics.md.md)[`downSample`]libs/basics.md#badownsample.md) | Down sample a signal
+[Impulsify]libs/basics.md#baimpulsify.md) | [`ba.`]libs/basics.md.md)[`impulsify`]libs/basics.md#baimpulsify.md) | Turns a signal into an impulse
+[Sample and Hold]libs/basics.md#basandh.md) | [`ba.`]libs/basics.md.md)[`sAndH`]libs/basics.md#basandh.md) | Sample and hold
+[Signal Crossing]libs/routes.md#rocross.md) | [`ro.`]libs/routes.md.md)[`cross`]libs/routes.md#rocross.md) | Cross n signals
+[Smoother (Default)]libs/signals.md#sismoo.md) | [`si.`]libs/signals.md.md)[`smoo`]libs/signals.md#sismoo.md) | Exponential smoothing
+[Smoother]libs/signals.md#sismooth.md) | [`si.`]libs/signals.md.md)[`smooth`]libs/signals.md#sismooth.md) | Exponential smoothing with controllable pole
+[Take Element]libs/basics.md#batake.md) | [`ba.`]libs/basics.md.md)[`take`]libs/basics.md#batake.md) | Take en element from a list
+[Time]libs/basics.md#batime.md) | [`ba.`]libs/basics.md.md)[`time`]libs/basics.md#batime.md) | A simple timer
 
 <div class="table-end"></div>
 
@@ -50,16 +50,16 @@ Function Type | Function Name | Description
 
 Function Type | Function Name | Description
 --- | --- | ---
-[dB to Linear](../libs/basics/#badb2linear) | [`ba.`](../libs/basics)[`db2linear`](../libs/basics/#badb2linear) | Converts dB to linear values
-[Linear to dB](../libs/basics/#balinear2db) | [`ba.`](../libs/basics)[`linear2db`](../libs/basics/#balinear2db) | Converts linear values to dB
-[MIDI Key to Hz](../libs/basics/#bamidikey2hz) | [`ba.`](../libs/basics)[`midikey2hz`](../libs/basics/#bamidikey2hz) | Converts a MIDI key number into a frequency
-[Hz to MIDI Key](../libs/basics/#bahz2midikey) | [`ba.`](../libs/basics)[`hz2midikey`](../libs/basics/#bahz2midikey) | Converts a frequency into MIDI key number
-[Pole to T60](../libs/basics/#bapole2tau) | [`ba.`](../libs/basics)[`pole2tau`](../libs/basics/#bapole2tau) | Converts a pole into a time constant (t60)
-[T60 to Pole](../libs/basics/#batau2pole) | [`ba.`](../libs/basics)[`tau2pole`](../libs/basics/#batau2pole) | Converts a time constant (t60) into a pole
-[Samples to Seconds](../libs/basics/#basamp2sec) | [`ba.`](../libs/basics)[`samp2sec`](../libs/basics/#basamp2sec) | Converts samples to seconds
-[Seconds to Samples](../libs/basics/#basec2samp) | [`ba.`](../libs/basics)[`sec2samp`](../libs/basics/#basec2samp) | Converts seconds to samples
-[Semitones to Frequency ratio](../libs/basics/#semi2ratio) | [`ba.`](../libs/basics)[`semi2ratio`](../libs/basics/#semi2ratio) | Converts semitones in a frequency multiplicative ratio
-[Frequency ratio to semintones](../libs/basics/#ratio2semi) | [`ba.`](../libs/basics)[`ratio2semi`](../libs/basics/#ratio2semi) | Converts a frequency multiplicative ratio in semitones
+[dB to Linear]libs/basics.md#badb2linear.md) | [`ba.`]libs/basics.md.md)[`db2linear`]libs/basics.md#badb2linear.md) | Converts dB to linear values
+[Linear to dB]libs/basics.md#balinear2db.md) | [`ba.`]libs/basics.md.md)[`linear2db`]libs/basics.md#balinear2db.md) | Converts linear values to dB
+[MIDI Key to Hz]libs/basics.md#bamidikey2hz.md) | [`ba.`]libs/basics.md.md)[`midikey2hz`]libs/basics.md#bamidikey2hz.md) | Converts a MIDI key number into a frequency
+[Hz to MIDI Key]libs/basics.md#bahz2midikey.md) | [`ba.`]libs/basics.md.md)[`hz2midikey`]libs/basics.md#bahz2midikey.md) | Converts a frequency into MIDI key number
+[Pole to T60]libs/basics.md#bapole2tau.md) | [`ba.`]libs/basics.md.md)[`pole2tau`]libs/basics.md#bapole2tau.md) | Converts a pole into a time constant (t60)
+[T60 to Pole]libs/basics.md#batau2pole.md) | [`ba.`]libs/basics.md.md)[`tau2pole`]libs/basics.md#batau2pole.md) | Converts a time constant (t60) into a pole
+[Samples to Seconds]libs/basics.md#basamp2sec.md) | [`ba.`]libs/basics.md.md)[`samp2sec`]libs/basics.md#basamp2sec.md) | Converts samples to seconds
+[Seconds to Samples]libs/basics.md#basec2samp.md) | [`ba.`]libs/basics.md.md)[`sec2samp`]libs/basics.md#basec2samp.md) | Converts seconds to samples
+[Semitones to Frequency ratio]libs/basics.md#semi2ratio.md) | [`ba.`]libs/basics.md.md)[`semi2ratio`]libs/basics.md#semi2ratio.md) | Converts semitones in a frequency multiplicative ratio
+[Frequency ratio to semintones]libs/basics.md#ratio2semi.md) | [`ba.`]libs/basics.md.md)[`ratio2semi`]libs/basics.md#ratio2semi.md) | Converts a frequency multiplicative ratio in semitones
 <div class="table-end"></div>
 
 
@@ -69,26 +69,26 @@ Function Type | Function Name | Description
 
 Function Type | Function Name | Description
 --- | --- | ---
-[Auto Wah](../libs/vaeffects/#veautowah) | [`ve.`](../libs/vaeffects)[`autowah`](../libs/vaeffects/#veautowah) | Auto-Wah effect
-[Compressor](../libs/compressors/#cocompressor_mono) | [`co.`](../libs/compressors)[`compressor_mono`](../libs/compressors/#cocompressor_mono) | Dynamic range compressor
-[Distortion](../libs/misceffects/#efcubicnl) | [`ef.`](../libs/misceffects)[`cubicnl`](../libs/misceffects/#efcubicnl) | Cubic nonlinearity distortion
-[Crybaby](../libs/vaeffects/#vecrybaby) | [`ve.`](../libs/vaeffects)[`crybaby`](../libs/vaeffects/#vecrybaby) | Crybaby wah pedal
-[Echo](../libs/misceffects/#efecho) | [`ef.`](../libs/misceffects)[`echo`](../libs/misceffects/#efecho) | Simple echo
-[Flanger](../libs/phaflangers/#pfflanger_stereo) | [`pf.`](../libs/phaflangers)[`flanger_stereo`](../libs/phaflangers/#pfflanger_stereo) | Flanging effect
-[Gate](../libs/misceffects/#efgate_mono) | [`ef.`](../libs/misceffects)[`gate_mono`](../libs/misceffects/#efgate_mono) | Mono signal gate
-[Limiter](../libs/compressors/#colimiter_1176_R4_mono) | [`co.`](../libs/compressors)[`limiter_1176_R4_mono`](../libs/compressors/#colimiter_1176_R4_mono) | Limiter
-[Phaser](../libs/phaflangers/#pfphaser2_stereo) | [`pf.`](../libs/phaflangers)[`phaser2_stereo`](../libs/phaflangers/#pfphaser2_stereo) | Phaser effect
-[Reverb (FDN)](../libs/reverbs/#refdnrev0) | [`re.`](../libs/reverbs)[`fdnrev0`](../libs/reverbs/#refdnrev0) | Feedback delay network reverberator
-[Reverb (Freeverb)](../libs/reverbs/#remono_freeverb) | [`re.`](../libs/reverbs)[`mono_freeverb`](../libs/reverbs/#remono_freeverb) | Most "famous" Schroeder reverberator
-[Reverb (Simple)](../libs/reverbs/#rejcrev) | [`re.`](../libs/reverbs)[`jcrev`](../libs/reverbs/#rejcrev) | Simple Schroeder reverberator
-[Reverb (Zita)](../libs/reverbs/#rezita_rev1_stereo) | [`re.`](../libs/reverbs)[`zita_rev1_stereo`](../libs/reverbs/#rezita_rev1_stereo) | High quality FDN reverberator
-[Panner](../libs/spats/#sppanner) | [`sp.`](../libs/spats)[`panner`](../libs/spats/#sppanner) | Linear stereo panner
-[Pitch Shift](../libs/misceffects/#eftranspose) | [`ef.`](../libs/misceffects)[`transpose`](../libs/misceffects/#eftranspose) | Simple pitch shifter
-[Panner](../libs/spats/#spspat) | [`sp.`](../libs/spats)[`spat`](../libs/spats/#spspat) | N outputs spatializer
-[Speaker Simulator](../libs/misceffects/#efspeakerbp) | [`ef.`](../libs/misceffects)[`speakerbp`](../libs/misceffects/#efspeakerbp) | Simple speaker simulator
-[Stereo Width](../libs/misceffects/#efstereo_width) | [`ef.`](../libs/misceffects)[`stereo_width`](../libs/misceffects/#efstereo_width) | Stereo width effect
-[Vocoder](../libs/vaeffects/#vevocoder) | [`ve.`](../libs/vaeffects)[`vocoder`](../libs/vaeffects/#vevocoder) | Simple vocoder
-[Wah](../libs/vaeffects/#vewah4) | [`ve.`](../libs/vaeffects)[`wah4`](../libs/vaeffects/#vewah4) | Wah effect
+[Auto Wah]libs/vaeffects.md#veautowah.md) | [`ve.`]libs/vaeffects.md.md)[`autowah`]libs/vaeffects.md#veautowah.md) | Auto-Wah effect
+[Compressor]libs/compressors.md#cocompressor_mono.md) | [`co.`]libs/compressors.md.md)[`compressor_mono`]libs/compressors.md#cocompressor_mono.md) | Dynamic range compressor
+[Distortion]libs/misceffects.md#efcubicnl.md) | [`ef.`]libs/misceffects.md.md)[`cubicnl`]libs/misceffects.md#efcubicnl.md) | Cubic nonlinearity distortion
+[Crybaby]libs/vaeffects.md#vecrybaby.md) | [`ve.`]libs/vaeffects.md.md)[`crybaby`]libs/vaeffects.md#vecrybaby.md) | Crybaby wah pedal
+[Echo]libs/misceffects.md#efecho.md) | [`ef.`]libs/misceffects.md.md)[`echo`]libs/misceffects.md#efecho.md) | Simple echo
+[Flanger]libs/phaflangers.md#pfflanger_stereo.md) | [`pf.`]libs/phaflangers.md.md)[`flanger_stereo`]libs/phaflangers.md#pfflanger_stereo.md) | Flanging effect
+[Gate]libs/misceffects.md#efgate_mono.md) | [`ef.`]libs/misceffects.md.md)[`gate_mono`]libs/misceffects.md#efgate_mono.md) | Mono signal gate
+[Limiter]libs/compressors.md#colimiter_1176_R4_mono.md) | [`co.`]libs/compressors.md.md)[`limiter_1176_R4_mono`]libs/compressors.md#colimiter_1176_R4_mono.md) | Limiter
+[Phaser]libs/phaflangers.md#pfphaser2_stereo.md) | [`pf.`]libs/phaflangers.md.md)[`phaser2_stereo`]libs/phaflangers.md#pfphaser2_stereo.md) | Phaser effect
+[Reverb (FDN)]libs/reverbs.md#refdnrev0.md) | [`re.`]libs/reverbs.md.md)[`fdnrev0`]libs/reverbs.md#refdnrev0.md) | Feedback delay network reverberator
+[Reverb (Freeverb)]libs/reverbs.md#remono_freeverb.md) | [`re.`]libs/reverbs.md.md)[`mono_freeverb`]libs/reverbs.md#remono_freeverb.md) | Most "famous" Schroeder reverberator
+[Reverb (Simple)]libs/reverbs.md#rejcrev.md) | [`re.`]libs/reverbs.md.md)[`jcrev`]libs/reverbs.md#rejcrev.md) | Simple Schroeder reverberator
+[Reverb (Zita)]libs/reverbs.md#rezita_rev1_stereo.md) | [`re.`]libs/reverbs.md.md)[`zita_rev1_stereo`]libs/reverbs.md#rezita_rev1_stereo.md) | High quality FDN reverberator
+[Panner]libs/spats.md#sppanner.md) | [`sp.`]libs/spats.md.md)[`panner`]libs/spats.md#sppanner.md) | Linear stereo panner
+[Pitch Shift]libs/misceffects.md#eftranspose.md) | [`ef.`]libs/misceffects.md.md)[`transpose`]libs/misceffects.md#eftranspose.md) | Simple pitch shifter
+[Panner]libs/spats.md#spspat.md) | [`sp.`]libs/spats.md.md)[`spat`]libs/spats.md#spspat.md) | N outputs spatializer
+[Speaker Simulator]libs/misceffects.md#efspeakerbp.md) | [`ef.`]libs/misceffects.md.md)[`speakerbp`]libs/misceffects.md#efspeakerbp.md) | Simple speaker simulator
+[Stereo Width]libs/misceffects.md#efstereo_width.md) | [`ef.`]libs/misceffects.md.md)[`stereo_width`]libs/misceffects.md#efstereo_width.md) | Stereo width effect
+[Vocoder]libs/vaeffects.md#vevocoder.md) | [`ve.`]libs/vaeffects.md.md)[`vocoder`]libs/vaeffects.md#vevocoder.md) | Simple vocoder
+[Wah]libs/vaeffects.md#vewah4.md) | [`ve.`]libs/vaeffects.md.md)[`wah4`]libs/vaeffects.md#vewah4.md) | Wah effect
 
 <div class="table-end"></div>
 
@@ -99,10 +99,10 @@ Function Type | Function Name | Description
 
 Function Type | Function Name | Description
 --- | --- | ---
-[ADSR](../libs/envelopes/#enasr) | [`en.`](../libs/envelopes)[`adsr`](../libs/envelopes/#enadsr) | Attack/Decay/Sustain/Release envelope generator
-[AR](../libs/envelopes/#enar) | [`en.`](../libs/envelopes)[`ar`](../libs/envelopes/#enar) | Attack/Release envelope generator
-[ASR](../libs/envelopes/#enasr) | [`en.`](../libs/envelopes)[`asr`](../libs/envelopes/#enasr) | Attack/Sustain/Release envelope generator
-[Exponential](../libs/envelopes/#ensmoothEvelope) | [`en.`](../libs/envelopes)[`smoothEnvelope`](../libs/envelopes/#ensmoothEnvelope) | Exponential envelope generator
+[ADSR]libs/envelopes.md#enasr.md) | [`en.`]libs/envelopes.md.md)[`adsr`]libs/envelopes.md#enadsr.md) | Attack/Decay/Sustain/Release envelope generator
+[AR]libs/envelopes.md#enar.md) | [`en.`]libs/envelopes.md.md)[`ar`]libs/envelopes.md#enar.md) | Attack/Release envelope generator
+[ASR]libs/envelopes.md#enasr.md) | [`en.`]libs/envelopes.md.md)[`asr`]libs/envelopes.md#enasr.md) | Attack/Sustain/Release envelope generator
+[Exponential]libs/envelopes.md#ensmoothEvelope.md) | [`en.`]libs/envelopes.md.md)[`smoothEnvelope`]libs/envelopes.md#ensmoothEnvelope.md) | Exponential envelope generator
 
 <div class="table-end"></div>
 
@@ -113,26 +113,26 @@ Function Type | Function Name | Description
 
 Function Type | Function Name | Description
 --- | --- | ---
-[Bandpass (Butterworth)](../libs/filters/#fibandpass) | [`fi.`](../libs/filters)[`bandpass`](../libs/filters/#fibandpass) | Generic butterworth bandpass
-[Bandpass (Resonant)](../libs/filters/#firesonbp) | [`fi.`](../libs/filters)[`resonbp`](../libs/filters/#firesonbp) | Virtual analog resonant bandpass
-[Bandstop (Butterworth)](../libs/filters/#fibandstop) | [`fi.`](../libs/filters)[`bandstop`](../libs/filters/#fibandstop) | Generic butterworth bandstop
-[Biquad](../libs/filters/#fitf2) | [`fi.`](../libs/filters)[`tf2`](../libs/filters/#fitf2) | "Standard" biquad filter
-[Comb (Allpass)](../libs/filters/#fiallpass_fcomb) | [`fi.`](../libs/filters)[`allpass_fcomb`](../libs/filters/#fiallpass_fcomb) | Schroeder allpass comb filter
-[Comb (Feedback)](../libs/filters/#fifb_fcomb) | [`fi.`](../libs/filters)[`fb_fcomb`](../libs/filters/#fifb_fcomb) | Feedback comb filter
-[Comb (Feedforward)](../libs/filters/#fiff_fcomb) | [`fi.`](../libs/filters)[`ff_fcomb`](../libs/filters/#fiff_fcomb) | Feed-forward comb filter.
-[DC Blocker](../libs/filters/#fidcblocker) | [`fi.`](../libs/filters)[`dcblocker`](../libs/filters/#fidcblocker) | Default dc blocker
-[Filterbank](../libs/filters/#fifilterbank) | [`fi.`](../libs/filters)[`filterbank`](../libs/filters/#fifilterbank) | Generic filter bank
-[FIR (Arbitrary Order)](../libs/filters/#fifir) | [`fi.`](../libs/filters)[`fir`](../libs/filters/#fifir) | Nth-order FIR filter
-[High Shelf](../libs/filters/#fihigh_shelf) | [`fi.`](../libs/filters)[`high_shelf`](../libs/filters/#fihigh_shelf) | High shelf
-[Highpass (Butterworth)](../libs/filters/#fihighpass) | [`fi.`](../libs/filters)[`highpass`](../libs/filters/#fihighpass) | Nth-order Butterworth highpass
-[Highpass (Resonant)](../libs/filters/#firesonhp) | [`fi.`](../libs/filters)[`resonhp`](../libs/filters/#firesonhp) | Virtual analog resonant highpass
-[IIR (Arbitrary Order)](../libs/filters/#fiiir) | [`fi.`](../libs/filters)[`iir`](../libs/filters/#fiiir) | Nth-order IIR filter
-[Level Filter](../libs/filters/#filevelfilter) | [`fi.`](../libs/filters)[`levelfilter`](../libs/filters/#filevelfilter) | Dynamic level lowpass
-[Low Shelf](../libs/filters/#filow_shelf) | [`fi.`](../libs/filters)[`low_shelf`](../libs/filters/#filow_shelf) | Low shelf
-[Lowpass (Butterworth)](../libs/filters/#filowpass) | [`fi.`](../libs/filters)[`lowpass`](../libs/filters/#filowpass) | Nth-order Butterworth lowpass
-[Lowpass (Resonant)](../libs/filters/#firesonlp) | [`fi.`](../libs/filters)[`resonlp`](../libs/filters/#firesonlp) | Virtual analog resonant lowpass
-[Notch Filter](../libs/filters/#finotchw) | [`fi.`](../libs/filters)[`notchw`](../libs/filters/#finotchw) | Simple notch filter
-[Peak Equalizer](../libs/filters/#fipeak_eq) | [`fi.`](../libs/filters)[`peak_eq`](../libs/filters/#fipeak_eq) | Peaking equalizer section
+[Bandpass (Butterworth)]libs/filters.md#fibandpass.md) | [`fi.`]libs/filters.md.md)[`bandpass`]libs/filters.md#fibandpass.md) | Generic butterworth bandpass
+[Bandpass (Resonant)]libs/filters.md#firesonbp.md) | [`fi.`]libs/filters.md.md)[`resonbp`]libs/filters.md#firesonbp.md) | Virtual analog resonant bandpass
+[Bandstop (Butterworth)]libs/filters.md#fibandstop.md) | [`fi.`]libs/filters.md.md)[`bandstop`]libs/filters.md#fibandstop.md) | Generic butterworth bandstop
+[Biquad]libs/filters.md#fitf2.md) | [`fi.`]libs/filters.md.md)[`tf2`]libs/filters.md#fitf2.md) | "Standard" biquad filter
+[Comb (Allpass)]libs/filters.md#fiallpass_fcomb.md) | [`fi.`]libs/filters.md.md)[`allpass_fcomb`]libs/filters.md#fiallpass_fcomb.md) | Schroeder allpass comb filter
+[Comb (Feedback)]libs/filters.md#fifb_fcomb.md) | [`fi.`]libs/filters.md.md)[`fb_fcomb`]libs/filters.md#fifb_fcomb.md) | Feedback comb filter
+[Comb (Feedforward)]libs/filters.md#fiff_fcomb.md) | [`fi.`]libs/filters.md.md)[`ff_fcomb`]libs/filters.md#fiff_fcomb.md) | Feed-forward comb filter.
+[DC Blocker]libs/filters.md#fidcblocker.md) | [`fi.`]libs/filters.md.md)[`dcblocker`]libs/filters.md#fidcblocker.md) | Default dc blocker
+[Filterbank]libs/filters.md#fifilterbank.md) | [`fi.`]libs/filters.md.md)[`filterbank`]libs/filters.md#fifilterbank.md) | Generic filter bank
+[FIR (Arbitrary Order)]libs/filters.md#fifir.md) | [`fi.`]libs/filters.md.md)[`fir`]libs/filters.md#fifir.md) | Nth-order FIR filter
+[High Shelf]libs/filters.md#fihigh_shelf.md) | [`fi.`]libs/filters.md.md)[`high_shelf`]libs/filters.md#fihigh_shelf.md) | High shelf
+[Highpass (Butterworth)]libs/filters.md#fihighpass.md) | [`fi.`]libs/filters.md.md)[`highpass`]libs/filters.md#fihighpass.md) | Nth-order Butterworth highpass
+[Highpass (Resonant)]libs/filters.md#firesonhp.md) | [`fi.`]libs/filters.md.md)[`resonhp`]libs/filters.md#firesonhp.md) | Virtual analog resonant highpass
+[IIR (Arbitrary Order)]libs/filters.md#fiiir.md) | [`fi.`]libs/filters.md.md)[`iir`]libs/filters.md#fiiir.md) | Nth-order IIR filter
+[Level Filter]libs/filters.md#filevelfilter.md) | [`fi.`]libs/filters.md.md)[`levelfilter`]libs/filters.md#filevelfilter.md) | Dynamic level lowpass
+[Low Shelf]libs/filters.md#filow_shelf.md) | [`fi.`]libs/filters.md.md)[`low_shelf`]libs/filters.md#filow_shelf.md) | Low shelf
+[Lowpass (Butterworth)]libs/filters.md#filowpass.md) | [`fi.`]libs/filters.md.md)[`lowpass`]libs/filters.md#filowpass.md) | Nth-order Butterworth lowpass
+[Lowpass (Resonant)]libs/filters.md#firesonlp.md) | [`fi.`]libs/filters.md.md)[`resonlp`]libs/filters.md#firesonlp.md) | Virtual analog resonant lowpass
+[Notch Filter]libs/filters.md#finotchw.md) | [`fi.`]libs/filters.md.md)[`notchw`]libs/filters.md#finotchw.md) | Simple notch filter
+[Peak Equalizer]libs/filters.md#fipeak_eq.md) | [`fi.`]libs/filters.md.md)[`peak_eq`]libs/filters.md#fipeak_eq.md) | Peaking equalizer section
 
 <div class="table-end"></div>
 
@@ -143,21 +143,21 @@ Function Type | Function Name | Description
 
 Function Type | Function Name | Description
 --- | --- | ---
-[Impulse](../libs/oscillators/#osimpulse) | [`os.`](../libs/oscillators)[`impulse`](../libs/oscillators/#osimpulse) | Generate an impulse on start-up
-[Impulse Train](../libs/oscillators/#osimptrain) | [`os.`](../libs/oscillators)[`imptrain`](../libs/oscillators/#osimptrain) | Band-limited impulse train
-[Phasor](../libs/oscillators/#osphasor) | [`os.`](../libs/oscillators)[`phasor`](../libs/oscillators/#osphasor) | Simple phasor
-[Pink Noise](../libs/noises/#nopink_noise) | [`no.`](../libs/noises)[`pink_noise`](../libs/noises/#nopink_noise) | Pink noise generator
-[Pulse Train](../libs/oscillators/#ospulsetrain) | [`os.`](../libs/oscillators)[`pulsetrain`](../libs/oscillators/#ospulsetrain) | Band-limited pulse train
-[Pulse Train (Low Frequency)](../libs/oscillators/#oslf_imptrain) | [`os.`](../libs/oscillators)[`lf_imptrain`](../libs/oscillators/#oslf_imptrain) | Low-frequency pulse train
-[Sawtooth](../libs/oscillators/#ossawtooth) | [`os.`](../libs/oscillators)[`sawtooth`](../libs/oscillators/#ossawtooth) | Band-limited sawtooth wave
-[Sawtooth (Low Frequency)](../libs/oscillators/#oslf_saw) | [`os.`](../libs/oscillators)[`lf_saw`](../libs/oscillators/#oslf_saw) | Low-frequency sawtooth wave
-[Sine (Filter-Based)](../libs/oscillators/#ososcs) | [`os.`](../libs/oscillators)[`oscs`](../libs/oscillators/#ososcs) | Sine oscillator (filter-based)
-[Sine (Table-Based)](../libs/oscillators/#ososc) | [`os.`](../libs/oscillators)[`osc`](../libs/oscillators/#ososc) | Sine oscillator (table-based)
-[Square](../libs/oscillators/#ossquare) | [`os.`](../libs/oscillators)[`square`](../libs/oscillators/#ossquare) | Band-limited square wave
-[Square (Low Frequency)](../libs/oscillators/#oslf_squarewave) | [`os.`](../libs/oscillators)[`lf_squarewave`](../libs/oscillators/#oslf_squarewave) | Low-frequency square wave
-[Triangle](../libs/oscillators/#ostriangle) | [`os.`](../libs/oscillators)[`triangle`](../libs/oscillators/#ostriangle) | Band-limited triangle wave
-[Triangle (Low Frequency)](../libs/oscillators/#oslf_triangle) | [`os.`](../libs/oscillators)[`lf_triangle`](../libs/oscillators/#oslf_triangle) | Low-frequency triangle wave
-[White Noise](../libs/noises/#nonoise) | [`no.`](../libs/noises)[`noise`](../libs/noises/#nonoise) | White noise generator
+[Impulse]libs/oscillators.md#osimpulse.md) | [`os.`]libs/oscillators.md.md)[`impulse`]libs/oscillators.md#osimpulse.md) | Generate an impulse on start-up
+[Impulse Train]libs/oscillators.md#osimptrain.md) | [`os.`]libs/oscillators.md.md)[`imptrain`]libs/oscillators.md#osimptrain.md) | Band-limited impulse train
+[Phasor]libs/oscillators.md#osphasor.md) | [`os.`]libs/oscillators.md.md)[`phasor`]libs/oscillators.md#osphasor.md) | Simple phasor
+[Pink Noise]libs/noises.md#nopink_noise.md) | [`no.`]libs/noises.md.md)[`pink_noise`]libs/noises.md#nopink_noise.md) | Pink noise generator
+[Pulse Train]libs/oscillators.md#ospulsetrain.md) | [`os.`]libs/oscillators.md.md)[`pulsetrain`]libs/oscillators.md#ospulsetrain.md) | Band-limited pulse train
+[Pulse Train (Low Frequency)]libs/oscillators.md#oslf_imptrain.md) | [`os.`]libs/oscillators.md.md)[`lf_imptrain`]libs/oscillators.md#oslf_imptrain.md) | Low-frequency pulse train
+[Sawtooth]libs/oscillators.md#ossawtooth.md) | [`os.`]libs/oscillators.md.md)[`sawtooth`]libs/oscillators.md#ossawtooth.md) | Band-limited sawtooth wave
+[Sawtooth (Low Frequency)]libs/oscillators.md#oslf_saw.md) | [`os.`]libs/oscillators.md.md)[`lf_saw`]libs/oscillators.md#oslf_saw.md) | Low-frequency sawtooth wave
+[Sine (Filter-Based)]libs/oscillators.md#ososcs.md) | [`os.`]libs/oscillators.md.md)[`oscs`]libs/oscillators.md#ososcs.md) | Sine oscillator (filter-based)
+[Sine (Table-Based)]libs/oscillators.md#ososc.md) | [`os.`]libs/oscillators.md.md)[`osc`]libs/oscillators.md#ososc.md) | Sine oscillator (table-based)
+[Square]libs/oscillators.md#ossquare.md) | [`os.`]libs/oscillators.md.md)[`square`]libs/oscillators.md#ossquare.md) | Band-limited square wave
+[Square (Low Frequency)]libs/oscillators.md#oslf_squarewave.md) | [`os.`]libs/oscillators.md.md)[`lf_squarewave`]libs/oscillators.md#oslf_squarewave.md) | Low-frequency square wave
+[Triangle]libs/oscillators.md#ostriangle.md) | [`os.`]libs/oscillators.md.md)[`triangle`]libs/oscillators.md#ostriangle.md) | Band-limited triangle wave
+[Triangle (Low Frequency)]libs/oscillators.md#oslf_triangle.md) | [`os.`]libs/oscillators.md.md)[`lf_triangle`]libs/oscillators.md#oslf_triangle.md) | Low-frequency triangle wave
+[White Noise]libs/noises.md#nonoise.md) | [`no.`]libs/noises.md.md)[`noise`]libs/noises.md#nonoise.md) | White noise generator
 
 <div class="table-end"></div>
 
@@ -168,12 +168,12 @@ Function Type | Function Name | Description
 
 Function Type | Function Name | Description
 --- | --- | ---
-[Additive Drum](../libs/synths/#syadditivedrum) | [`sy.`](../libs/synths)[`additiveDrum`](../libs/synths/#syadditivedrum) | Additive synthesis drum
-[Bandpassed Sawtooth](../libs/synths/#sydubdub) | [`sy.`](../libs/synths)[`dubDub`](../libs/synths/#sydubdub) | Sawtooth through resonant bandpass
-[Comb String](../libs/synths/#sycombstring) | [`sy.`](../libs/synths)[`combString`](../libs/synths/#sycombstring) | String model based on a comb filter
-[FM](../libs/synths/#syfm) | [`sy.`](../libs/synths)[`fm`](../libs/synths/#syfm) | Frequency modulation synthesizer
-[Lowpassed Sawtooth](../libs/synths/#sysawtrombone) | [`sy.`](../libs/synths)[`sawTrombone`](../libs/synths/#sysawtrombone) | "Trombone" based on a filtered sawtooth
-[Popping Filter](../libs/synths/#sypopfilterperc) | [`sy.`](../libs/synths)[`popFilterPerc`](../libs/synths/#sypopfilterperc) | Popping filter percussion instrument
+[Additive Drum]libs/synths.md#syadditivedrum.md) | [`sy.`]libs/synths.md.md)[`additiveDrum`]libs/synths.md#syadditivedrum.md) | Additive synthesis drum
+[Bandpassed Sawtooth]libs/synths.md#sydubdub.md) | [`sy.`]libs/synths.md.md)[`dubDub`]libs/synths.md#sydubdub.md) | Sawtooth through resonant bandpass
+[Comb String]libs/synths.md#sycombstring.md) | [`sy.`]libs/synths.md.md)[`combString`]libs/synths.md#sycombstring.md) | String model based on a comb filter
+[FM]libs/synths.md#syfm.md) | [`sy.`]libs/synths.md.md)[`fm`]libs/synths.md#syfm.md) | Frequency modulation synthesizer
+[Lowpassed Sawtooth]libs/synths.md#sysawtrombone.md) | [`sy.`]libs/synths.md.md)[`sawTrombone`]libs/synths.md#sysawtrombone.md) | "Trombone" based on a filtered sawtooth
+[Popping Filter]libs/synths.md#sypopfilterperc.md) | [`sy.`]libs/synths.md.md)[`popFilterPerc`]libs/synths.md#sypopfilterperc.md) | Popping filter percussion instrument
 
 <div class="table-end"></div>
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,5 +1,4 @@
 site_name: Faust Libraries 
-title_brand: Libraries
 site_description: Faust Libraries Documentation.
 copyright: Copyright &copy; 2019-2024 <a href="https://www.grame.fr">Grame-CNCM</a>
 

--- a/doc/scripts/faustlib2md.awk
+++ b/doc/scripts/faustlib2md.awk
@@ -13,7 +13,7 @@ function makeurl(arg) {
 
 		gsub(":", "://", url);			# for malformed url
 		gsub(/\/\/\/\//, "//", url);	# to fix redundant //// 
-		gsub(/<http..*>/, "["url"]("url")", arg);
+		gsub(/<http..*>/, "["url"]("url".md)", arg);
 		return "* "arg;
 	}
 	return arg;

--- a/doc/scripts/makeindex.awk
+++ b/doc/scripts/makeindex.awk
@@ -35,5 +35,5 @@ END {
 	link = fun;
 	gsub(/[\[\]\|\(\)\.]/, "", link); 	# remove () [] | and .
 	gsub(" ", "-", link);   				# replace space with -
-	print "[" fun "](" SECTION "/#" tolower(link) ") &nbsp; &nbsp;";
+	print "[" fun "](" SECTION ".md#" tolower(link) ") &nbsp; &nbsp;";
 }

--- a/doc/theme/base.html
+++ b/doc/theme/base.html
@@ -30,7 +30,7 @@
 
       {%- block libs %}
 
-        <script src="{{ 'js/jquery-1.10.2.min.js'|url }}" defer></script>
+        <script src="{{ 'js/jquery-3.6.0.min.js'|url }}" defer></script>
         <script src="{{ 'js/bootstrap.min.js'|url }}" defer></script>
         {%- if config.theme.highlightjs %}
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>


### PR DESCRIPTION
Updated Makefile to force mkdocs to a fixed version.
Updated mkdocs/theme/base.html to use jquery-3.6.0.min.js as provided by mkdocs 1.5.3

This prevents numerous errors caused by significant changes in newer mkdocs versions.