### PR TITLE
Use FAUSTLIBS var instead of a static path in SRC var definition

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,7 +6,7 @@ DOCDIR   := docs
 SITEDIR	 := ../docs
 FAUSTLIBS ?= ../../faustlibraries
 
-SRC   	 := $(shell cat ../../faustlibraries/all.lib | grep import | sed -e 's/[^"]*"\(..*\.lib\).*/\1/')
+SRC   	 := $(shell cat $(FAUSTLIBS)/all.lib | grep import | sed -e 's/[^"]*"\(..*\.lib\).*/\1/')
 MD   	 := $(SRC:%.lib=$(DOCDIR)/libs/%.md)
 LIST   	 := $(SRC:%.lib=%)
 


### PR DESCRIPTION
This one is quite simple and allows correct use of the FAUSTLIBS var troughout the Makefile.