### PR TITLE
add anti-aliased quadratic softclip

### DIFF
--- a/aanl.lib
+++ b/aanl.lib
@@ -339,7 +339,7 @@ parabolic2(x) = ADAA2(EPS, f, F1, F2, x)
 //
 // First-order ADAA hyperbolic saturator.
 //
-// The domain of this function is ℝ; its theoretical range is ]-1.0; 1.0[.
+// The domain of this function is ℝ; its theoretical range is [-1.0; 1.0].
 //
 // #### Usage
 // ```
@@ -362,7 +362,7 @@ hyperbolic(x) = ADAA1(EPS, f, F1, x)
 //
 // Second-order ADAA hyperbolic saturator.
 //
-// The domain of this function is ℝ; its theoretical range is ]-1.0; 1.0[.
+// The domain of this function is ℝ; its theoretical range is [-1.0; 1.0].
 //
 // #### Usage
 // ```
@@ -387,7 +387,7 @@ hyperbolic2(x) = ADAA2(EPS, f, F1, F2, x)
 //
 // First-order ADAA sin(atan()) saturator.
 //
-// The domain of this function is ℝ; its theoretical range is ]-1.0; 1.0[.
+// The domain of this function is ℝ; its theoretical range is [-1.0; 1.0].
 //
 // #### Usage
 // ```
@@ -413,7 +413,7 @@ sinarctan(x) = ADAA1(EPS, f, F1, x)
 //
 // Second-order ADAA sin(atan()) saturator.
 //
-// The domain of this function is ℝ; its theoretical range is ]-1.0; 1.0[.
+// The domain of this function is ℝ; its theoretical range is [-1.0; 1.0].
 //
 // #### Usage
 // ```
@@ -436,11 +436,50 @@ sinarctan2(x) = ADAA2(EPS, f, F1, F2, x)
       };
 
 
+//-------`(aa.)softclipQuadratic`---------------------
+//
+// First-order ADAA quadratic softclip.
+//
+// The domain of this function is ℝ; its theoretical range is [-1.0; 1.0].
+//
+// #### Usage
+// ```
+// _ : aa.softclipQuadratic : _
+// ```
+//----------------------------------------------
+declare softclipQuadratic author "David Braun";
+declare softclipQuadratic copyright "Copyright (C) 2024 David Braun";
+declare softclipQuadratic license "MIT license";
+
+softclipQuadratic(x) = ADAA1(EPS, softclip, F1, x)
+with {
+    // this non anti-aliased version exists in misceffects.lib
+    softclip(x) = ba.ifNcNo(2, 1, 
+        absX < 1/3, 2*x,
+        absX < 2/3, ma.signum(x)*(3-(2-abs(3*x))^2)/3,
+        ma.signum(x)
+        )
+    with {
+        absX = abs(x);
+    };
+    EPS = 1.0 / ma.SR;
+
+    F1(x) = ba.ifNcNo(2, 1,
+        absX < 1/3, x^2,
+        absX < 2/3, -1.*absX/3+2*x^2-absX^3+1/27,
+        absX - 7/27
+    )
+    with {
+        absX = abs(x);
+    };
+};
+
+
 //-------`(aa.)tanh1`---------------------
 //
 // First-order ADAA tanh() saturator.
 //
-// The domain of this function is ℝ; its theoretical range is ]-1.0; 1.0[.
+// The domain of this function is ℝ; its theoretical range is [-1.0; 1.0].
 //
 // #### Usage
 // ```
@@ -856,7 +895,7 @@ tangent(x) = ADAA1(EPS, f, F1, x)
 //
 // First-order ADAA atanh(). 
 //
-// The domain of this function is ]-1.0; 1.0[; its theoretical range is ℝ.
+// The domain of this function is [-1.0; 1.0]; its theoretical range is ℝ.
 //
 // #### Usage
 // ```
@@ -879,7 +918,7 @@ atanh1(x) = ADAA1(EPS, f, F1, x)
 //
 // Second-order ADAA atanh().
 //
-// The domain of this function is ]-1.0; 1.0[; its theoretical range is ℝ.
+// The domain of this function is [-1.0; 1.0]; its theoretical range is ℝ.
 //
 // #### Usage
 // ```

--- a/misceffects.lib
+++ b/misceffects.lib
@@ -996,18 +996,6 @@ nonlinearityEnv = environment
     optionalNegate(y) = ba.if(x<0, -y, y);
   };
 
-  // Quadratic Soft-Clip
-  // coded by David Braun
-  // Reference:
-  // M. Schetzen: The Volterra and Wiener Theories of Nonlinear Systems. Robert Krieger Publishing, 1980.
-  softclipQuadratic(x) = makeOdd(f, x)
-  with {
-    f(x) = ba.if(x <= 1./3., 2*x, ba.if(x <= 2./3.,y,1))
-    with {
-      y = (3-(2-3*x)^2)/3;
-    };
-  };
-
   // Wavefolder/Wavefolding
   // coded by David Braun
   // Reference: Chapter 10: Nonlinear Processing. Figure 10.7
@@ -1034,10 +1022,24 @@ nonlinearityEnv = environment
 // ```
 // _ : softclipQuadratic : _;
 // ```
+//
+// #### References
+//
+// * U. Zölzer: Digital Audio Signal Processing. John Wiley & Sons Ltd, 2022.
 //---------------------------------------------------------------------------------------
 declare softclipQuadratic author "David Braun";
+declare softclipQuadratic copyright "Copyright (C) 2024 David Braun";
+declare softclipQuadratic license "MIT license";
 
-softclipQuadratic = nonlinearityEnv.softclipQuadratic;
+softclipQuadratic(x) = ba.ifNcNo(2, 1, 
+    absX < 1/3, 2*x,
+    absX <= 2/3, ma.signum(x)*(3-(2-abs(3*x))^2)/3,
+    ma.signum(x)
+    )
+with {
+    absX = abs(x);
+};
+
 
 //---------------`(ef.)wavefold`-------------------------------------------------
 // Wavefolding nonlinearity.


### PR DESCRIPTION
```faust
import("stdfaust.lib");

declare softclipQuadratic author "David Braun";
declare softclipQuadratic copyright "Copyright (C) 2024 David Braun";
declare softclipQuadratic license "MIT license";

softclipQuadratic(x) = aa.ADAA1(EPS, softclip, F1, x)
with {
    // this non anti-aliased version exists in misceffects.lib
    softclip(x) = ba.ifNcNo(2, 1, 
        absX < 1/3, 2*x,
        absX < 2/3, ma.signum(x)*(3-(2-abs(3*x))^2)/3,
        ma.signum(x)
        )
    with {
        absX = abs(x);
    };
    EPS = 1.0 / ma.SR;

    F1(x) = ba.ifNcNo(2, 1,
        absX < 1/3, x^2,
        absX < 2/3, -1.*absX/3+2*x^2-absX^3+1/27,
        absX - 7/27
    )
    with {
        absX = abs(x);
    };
};

// process = -1 + ba.time/100 : softclipQuadratic; // plot first samples of this
process = _*gain : ef.dryWetMixer(wet, softclipQuadratic) <: _, _
with {
    gain = hslider("gain [unit:dB]", 0, 0, 20, .01) : ba.db2linear;
    wet = hslider("wet", 1, 0, 1, .001);
};
```

Plotting first samples of `process = -1 + ba.time/100 : softclipQuadratic;`
<img width="479" alt="image" src="https://github.com/user-attachments/assets/b603e2de-dcaa-4a18-a209-e8a7382ac0f0">

[Desmos graph](https://www.desmos.com/calculator/qzn6flgosg)
<img width="453" alt="image" src="https://github.com/user-attachments/assets/982c3bb9-2861-48b9-a534-ae5731eeda8e">
The intersection and tangent points are at x=-2/3, -1/3, 1/3, 2/3 and the red line goes through the origin.