### PR TITLE
Add second-order anti-aliased softclip

### DIFF
--- a/aanl.lib
+++ b/aanl.lib
@@ -436,6 +436,43 @@ sinarctan2(x) = ADAA2(EPS, f, F1, F2, x)
       };
 
 
+softclipEnv = environment {
+    // this non anti-aliased version exists in misceffects.lib
+    softclip(x) = ba.ifNcNo(2, 1, 
+        absX < 1/3, 2*x,
+        absX < 2/3, ma.signum(x)*(3-(2-absX*3)^2)/3,
+        ma.signum(x)
+        )
+    with {
+        s = ba.if(x>0, 1, -1); // faster than ma.signum(x)
+        absX = abs(x);
+    };
+    EPS = 1.0 / ma.SR;
+
+    F1(x) = ba.ifNcNo(2, 1,
+        absX < 1/3, x^2,
+        absX < 2/3, -1.*absX/3+2*x^2-absX^3+1/27,
+        absX - 7/27
+    )
+    with {
+        absX = abs(x);
+    };
+
+    F2(x) = ba.ifNcNo(2, 1,
+        absX < 1/3, (2/3)*(x^3),
+        absX < 2/3, s*((-1/6)*(x^2)-(3/4)*(x^4)+1/324) + (4/3)*(x^3),
+        s*((0.5)*(x^2) - 5/108)
+    )
+    with {
+        s = ba.if(x>0, 1, -1); // faster than ma.signum(x)
+        absX = abs(x);
+    };
+
+    softclipQuadratic1 = ADAA1(EPS, softclip, F1);
+    softclipQuadratic2 = ADAA2(EPS, softclip, F1, F2);
+}
+
+
 //-------`(aa.)softclipQuadratic1`---------------------
 //
 // First-order ADAA quadratic softclip.
@@ -451,28 +488,25 @@ declare softclipQuadratic1 author "David Braun";
 declare softclipQuadratic1 copyright "Copyright (C) 2024 David Braun";
 declare softclipQuadratic1 license "MIT license";
 
-softclipQuadratic1(x) = ADAA1(EPS, softclip, F1, x)
-with {
-    // this non anti-aliased version exists in misceffects.lib
-    softclip(x) = ba.ifNcNo(2, 1, 
-        absX < 1/3, 2*x,
-        absX < 2/3, ma.signum(x)*(3-(2-abs(3*x))^2)/3,
-        ma.signum(x)
-        )
-    with {
-        absX = abs(x);
-    };
-    EPS = 1.0 / ma.SR;
+softclipQuadratic1 = softclipEnv.softclipQuadratic1;
 
-    F1(x) = ba.ifNcNo(2, 1,
-        absX < 1/3, x^2,
-        absX < 2/3, -1.*absX/3+2*x^2-absX^3+1/27,
-        absX - 7/27
-    )
-    with {
-        absX = abs(x);
-    };
-};
+
+//-------`(aa.)softclipQuadratic2`---------------------
+//
+// Second-order ADAA quadratic softclip.
+//
+// The domain of this function is ℝ; its theoretical range is [-1.0; 1.0].
+//
+// #### Usage
+// ```
+// _ : aa.softclipQuadratic2 : _
+// ```
+//----------------------------------------------
+declare softclipQuadratic2 author "David Braun";
+declare softclipQuadratic2 copyright "Copyright (C) 2024 David Braun";
+declare softclipQuadratic2 license "MIT license";
+
+softclipQuadratic2 = softclipEnv.softclipQuadratic2;
 
 
 //-------`(aa.)tanh1`---------------------
@@ -502,7 +536,7 @@ tanh1(x) = ADAA1(EPS, f, F1, x)
 //
 // First-order ADAA atan().
 //
-// The domain of this function is ℝ; its theoretical range is ]-π/2.0; π/2.0[.
+// The domain of this function is ℝ; its theoretical range is [-π/2.0; π/2.0].
 //
 // #### Usage
 // ```

--- a/misceffects.lib
+++ b/misceffects.lib
@@ -1033,7 +1033,7 @@ declare softclipQuadratic license "MIT license";
 
 softclipQuadratic(x) = ba.ifNcNo(2, 1, 
     absX < 1/3, 2*x,
-    absX <= 2/3, ma.signum(x)*(3-(2-abs(3*x))^2)/3,
+    absX <= 2/3, ma.signum(x)*(3-(2-absX*3)^2)/3,
     ma.signum(x)
     )
 with {


### PR DESCRIPTION
Example:
```faust
import("stdfaust.lib");

softclipEnv = environment {
    // this non anti-aliased version exists in misceffects.lib
    softclip(x) = ba.ifNcNo(2, 1, 
        absX < 1/3, 2*x,
        absX < 2/3, ma.signum(x)*(3-(2-absX*3)^2)/3,
        ma.signum(x)
        )
    with {
        s = ba.if(x>0, 1, -1); // faster than ma.signum(x)
        absX = abs(x);
    };
    EPS = 1.0 / ma.SR;

    F1(x) = ba.ifNcNo(2, 1,
        absX < 1/3, x^2,
        absX < 2/3, -1.*absX/3+2*x^2-absX^3+1/27,
        absX - 7/27
    )
    with {
        absX = abs(x);
    };

    F2(x) = ba.ifNcNo(2, 1,
        absX < 1/3, (2/3)*(x^3),
        absX < 2/3, s*((-1/6)*(x^2)-(3/4)*(x^4)+1/324) + (4/3)*(x^3),
        ((0.5)*(x^2) - 5/108)*s
    )
    with {
        s = ba.if(x>0, 1, -1); // faster than ma.signum(x)
        absX = abs(x);
    };

    softclipQuadratic1 = aa.ADAA1(EPS, softclip, F1);
    softclipQuadratic2 = aa.ADAA2(EPS, softclip, F1, F2);
}

with {

};

// process = -1 + ba.time/100 : aa.arcsin2; // plot first samples of this
// process = -1.1 + ba.time/100 : aa.hardclip2;
process = -1 + ba.time/100 : softclipEnv.softclipQuadratic2; // plot first samples of this
// process = _*gain : ef.dryWetMixer(wet, softclipQuadratic2) <: _, _
// with {
//     gain = hslider("gain [unit:dB]", 0, 0, 20, .01) : ba.db2linear;
//     wet = hslider("wet", 1, 0, 1, .001);
// };
```