### PR TITLE
Fix delay compensation in Lowpass Feedback Comb Filter

### DIFF
--- a/reverbs.lib
+++ b/reverbs.lib
@@ -671,7 +671,7 @@ with {
     
     // Lowpass Feedback Combfilter:
     // <https://ccrma.stanford.edu/~jos/pasp/Lowpass_Feedback_Comb_Filter.html>
-    lbcf(dt, fb, damp) = (+:@(dt)) ~ (*(1-damp) : (+ ~ *(damp)) : *(fb));
+    lbcf(dt, fb, damp) = (+ : @ (max(0, (dt - 1)))) ~ (*(1-damp) : (+ ~ *(damp)) : *(fb)) : mem;
      
     origSR = 44100;
     adaptSR(val) = val*ma.SR/origSR : int;


### PR DESCRIPTION
I encountered a discrepancy in the Lowpass Feedback Comb Filter within re.mono_freeverb. The filter does not compensate for the 1-sample delay introduced by the feedback in FAUST. Currently, when setting the function lbcf(dt, fb, damp), the delay in the second tap of the signal results in 2 * dt + 1 samples, instead of the expected 2 * dt samples due to the additional sample delay in the feedback path. To resolve this issue, I modified the function to delay by (dt - 1) in the feedback path, ensuring correct alignment. I also added a mem at the end of the circuit to preserve the correct delay in the feedforward path. This change ensures that the feedback delay is aligned properly, avoiding any additional unintended delay.