### PR TITLE
Update quantizers.lib

### DIFF
--- a/quantizers.lib
+++ b/quantizers.lib
@@ -93,10 +93,11 @@ with{
 //------------------------
 quantizeSmoothed(rf,nl) = _<: octave,_ <: _,!,noteRatio(nN) : rf*_*_
 with{
-    octave = (qLog(_)-log(rf))/log(2)<:
-        (_<0)*(1/(1<<(-1*(_-1)):int))+
-        (_>0)*(1<<(_:int))+
-		(_==0)*2;
+    octave = (qLog(_)-log(rf))/log(2)<: select3((_>0)+(_>=0),
+        (1/(1<<int(1-_))),
+        2,
+        1<<int(_)
+    );
     nN = ba.count(nl);
     noteRatio(1,oct) = findValue(1,oct);
     noteRatio(n,oct) = _ <: (ba.take(n,nl)<=((_/oct)/rf))*findValue(n,oct)+

--- a/quantizers.lib
+++ b/quantizers.lib
@@ -67,9 +67,7 @@ qSmooth(x) = ba.tabulate(1,0.5*atan(_*20-10)/1.4711+0.5,TableSize,0,1,x).cub;
 //------------------------
 quantize(rf,nl) = _<: octave,_ <: _,!,noteRatio(nN) : rf*_*_
 with{
-    octave = (qLog(_)-log(rf))/log(2)<:
-        (_<0)*(1/(1<<(-1*(_-1)):int))+
-        (_>=0)*(1<<(_:int));
+    octave = (qLog(_)-log(rf))/log(2) <: select2(_<0, 1<<int(_), 1/(1<<int(1-_)));
     nN = ba.count(nl);
     noteRatio(1,oct) = 1;
     noteRatio(n,oct) = _ <: (ba.take(n,nl)<=((_/oct)/rf))*ba.take(n,nl)+


### PR DESCRIPTION
`select2` is better than the previous `_ <: (_<0)*foo(_) + (_>=0)*bar(_)`. This fixes an issue I observed when trying to deploy code on a Daisy Pod. I think the code was trying to left shift by a negative number of bits, and this is undefined.