### PR TITLE
Add Vicanek's decramped second-order resonant filters

### DIFF
--- a/filters.lib
+++ b/filters.lib
@@ -3668,6 +3668,8 @@ biquad(b0, b1, b2, a1, a2, x) = f ~ _
 //---------- (fi.)lowpass2Matched ----------------------------------------------
 // Vicanek's decramped second-order resonant lowpass filter.
 //
+// Note that these filters require double-precision.
+//
 // #### Usage:
 // ```
 // _ : lowpass2Matched(CF, Q) : _;
@@ -3709,6 +3711,8 @@ lowpass2Matched(CF, Q, x) = biquad(b0, b1, b2, a1, a2, x)
 //---------- (fi.)highpass2Matched ----------------------------------------------
 // Vicanek's decramped second-order resonant highpass filter.
 //
+// Note that these filters require double-precision.
+//
 // #### Usage:
 // ```
 // _ : highpass2Matched(CF, Q) : _;
@@ -3746,6 +3750,8 @@ highpass2Matched(CF, Q, x) = biquad(b0, b1, b2, a1, a2, x)
 
 //---------- (fi.)bandpass2Matched ----------------------------------------------
 // Vicanek's decramped second-order resonant bandpass filter.
+//
+// Note that these filters require double-precision.
 //
 // #### Usage:
 // ```
@@ -3788,6 +3794,8 @@ bandpass2Matched(CF, Q, x) = biquad(b0, b1, b2, a1, a2, x)
 
 //---------- (fi.)peaking2Matched ----------------------------------------------
 // Vicanek's decramped second-order resonant bandpass filter.
+//
+// Note that these filters require double-precision.
 //
 // #### Usage:
 // ```

--- a/filters.lib
+++ b/filters.lib
@@ -26,6 +26,7 @@
 // * [Standardized Filters](#standardized-filters)
 // * [Averaging Functions](#averaging-functions)
 // * [Kalman Filters](#kalman-filters)
+// * [Vicanek's matched (decramped) second-order filters](#matched-filters)
 //
 // #### References
 // * <https://github.com/grame-cncm/faustlibraries/blob/master/filters.lib>
@@ -3639,6 +3640,196 @@ kalmanEnv = environment {
 declare kalman author "David Braun";
 declare kalman license "MIT License";
 kalman = kalmanEnv.kalmanFilter;
+
+
+/*******************************************************************************
+****** Vicanek's matched (decramped) second-order filters **********************
+*******************************************************************************/
+//---------- (fi.)biquad -------------------------------------------------------
+// Basic biquad section implementing the difference equation:
+// y[n] = b0 * x[n] + b1 * x[n-1] + b2 * x[n-2] - a1 * y[n-1] - a2 * y[n-2]
+//
+// #### Usage:
+// ```
+// _ : biquad(b0, b1, b2, a1, a2) : _;
+// ```
+//
+// #### Where:
+//
+// * b0, b1, b2, a1, a2 are the coefficients of the difference equation above.
+//
+declare biquad author "Dario Sanfilippo";
+declare biquad license "MIT License";
+biquad(b0, b1, b2, a1, a2, x) = f ~ _
+    with {
+        f(s) = b0 * x + b1 * x' + b2 * x'' - a1 * s - a2 * s';
+    };
+
+//---------- (fi.)lowpass2Matched ----------------------------------------------
+// Vicanek's decramped second-order resonant lowpass filter.
+//
+// #### Usage:
+// ```
+// _ : lowpass2Matched(CF, Q) : _;
+// ```
+//
+// #### Where:
+//
+// * `CF`: cutoff frequency in Hz.
+// * `Q`: resonance linear amplitude.
+//
+// #### References:
+//
+// * <https://www.vicanek.de/articles/BiquadFits.pdf>
+//
+declare lowpass2Matched author "Dario Sanfilippo";
+declare lowpass2Matched license "MIT License";
+lowpass2Matched(CF, Q, x) = biquad(b0, b1, b2, a1, a2, x)
+    with {
+        q = 1.0 / (2.0 * Q);
+        w = 2.0 * ma.PI * CF * ma.T;
+        a1Less = -2.0 * exp(-1.0 * q * w) * cos(sqrt(max(.0, 1.0 - q * q)) * w);
+        a1More = -2.0 * exp(-1.0 * q * w) * ma.cosh(sqrt(max(.0, q * q - 1.0)) * w);
+        a1 = ba.if(q <= 1.0, a1Less, a1More);
+        a2 = exp(-2.0 * q * w);
+        phi0 = 1.0 - sin(.5 * w) ^ 2.0;
+        phi1 = sin(.5 * w) ^ 2.0;
+        phi2 = 4.0 * phi0 * phi1;
+        A0 = (1.0 + a1 + a2) ^ 2.0;
+        A1 = (1.0 - a1 + a2) ^ 2.0;
+        A2 = -4.0 * a2;
+        R1 = (A0 * phi0 + A1 * phi1 + A2 * phi2) * Q * Q;
+        B0 = A0;
+        B1 = (R1 - B0 * phi0) / phi1;
+        b0 = .5 * (sqrt(B0) + sqrt(B1));
+        b1 = sqrt(B0) - b0;
+        b2 = .0;
+    };
+
+//---------- (fi.)highpass2Matched ----------------------------------------------
+// Vicanek's decramped second-order resonant highpass filter.
+//
+// #### Usage:
+// ```
+// _ : highpass2Matched(CF, Q) : _;
+// ```
+//
+// #### Where:
+//
+// * `CF`: cutoff frequency in Hz.
+// * `Q`: resonance linear amplitude.
+//
+// #### References:
+//
+// * <https://www.vicanek.de/articles/BiquadFits.pdf>
+//
+declare highpass2Matched author "Dario Sanfilippo";
+declare highpass2Matched license "MIT License";
+highpass2Matched(CF, Q, x) = biquad(b0, b1, b2, a1, a2, x)
+    with {
+        q = 1.0 / (2.0 * Q);
+        w = 2.0 * ma.PI * CF * ma.T;
+        a1Less = -2.0 * exp(-1.0 * q * w) * cos(sqrt(max(.0, 1.0 - q * q)) * w);
+        a1More = -2.0 * exp(-1.0 * q * w) * ma.cosh(sqrt(max(.0, q * q - 1.0)) * w);
+        a1 = ba.if(q <= 1.0, a1Less, a1More);
+        a2 = exp(-2.0 * q * w);
+        phi0 = 1.0 - sin(.5 * w) ^ 2.0;
+        phi1 = sin(.5 * w) ^ 2.0;
+        phi2 = 4.0 * phi0 * phi1;
+        A0 = (1.0 + a1 + a2) ^ 2.0;
+        A1 = (1.0 - a1 + a2) ^ 2.0;
+        A2 = -4.0 * a2;
+        b0 = Q * sqrt(A0 * phi0 + A1 * phi1 + A2 * phi2) / (4.0 * phi1);
+        b1 = -2.0 * b0;
+        b2 = b0;
+    };
+
+//---------- (fi.)bandpass2Matched ----------------------------------------------
+// Vicanek's decramped second-order resonant bandpass filter.
+//
+// #### Usage:
+// ```
+// _ : bandpass2Matched(CF, Q) : _;
+// ```
+//
+// #### Where:
+//
+// * `CF`: cutoff frequency in Hz.
+// * `Q`: resonance linear amplitude.
+//
+// #### References:
+//
+// * <https://www.vicanek.de/articles/BiquadFits.pdf>
+//
+declare bandpass2Matched author "Dario Sanfilippo";
+declare bandpass2Matched license "MIT License";
+bandpass2Matched(CF, Q, x) = biquad(b0, b1, b2, a1, a2, x)
+    with {
+        q = 1.0 / (2.0 * Q);
+        w = 2.0 * ma.PI * CF * ma.T;
+        a1Less = -2.0 * exp(-1.0 * q * w) * cos(sqrt(max(.0, 1.0 - q * q)) * w);
+        a1More = -2.0 * exp(-1.0 * q * w) * ma.cosh(sqrt(max(.0, q * q - 1.0)) * w);
+        a1 = ba.if(q <= 1.0, a1Less, a1More);
+        a2 = exp(-2.0 * q * w);
+        phi0 = 1.0 - sin(.5 * w) ^ 2.0;
+        phi1 = sin(.5 * w) ^ 2.0;
+        phi2 = 4.0 * phi0 * phi1;
+        A0 = (1.0 + a1 + a2) ^ 2.0;
+        A1 = (1.0 - a1 + a2) ^ 2.0;
+        A2 = -4.0 * a2;
+        R1 = A0 * phi0 + A1 * phi1 + A2 * phi2;
+        R2 = -1.0 * A0 + A1 + 4.0 * (phi0 - phi1) * A2;
+        B1 = R2 + 4.0 * (phi1 - phi0) * B2;
+        B2 = (R1 - R2 * phi1) / (4.0 * phi1 * phi1);
+        b0 = .5 * (sqrt(B2 + b1 * b1) - b1);
+        b1 = -.5 * sqrt(B1);
+        b2 = -1.0 * (b0 + b1);
+    };
+
+//---------- (fi.)peaking2Matched ----------------------------------------------
+// Vicanek's decramped second-order resonant bandpass filter.
+//
+// #### Usage:
+// ```
+// _ : bandpass2Matched(G, CF, Q) : _;
+// ```
+//
+// #### Where:
+//
+// * `G`: peak linear amplitude
+// * `CF`: cutoff frequency in Hz.
+// * `Q`: peak width.
+//
+// #### References:
+//
+// * <https://www.vicanek.de/articles/BiquadFits.pdf>
+//
+declare peaking2Matched author "Dario Sanfilippo";
+declare peaking2Matched license "MIT License";
+peaking2Matched(G, CF, Q, x) = biquad(b0, b1, b2, a1, a2, x)
+    with {
+        q = 1.0 / (2.0 * Q);
+        w = 2.0 * ma.PI * CF * ma.T;
+        a1Less = -2.0 * exp(-1.0 * q * w) * cos(sqrt(max(.0, 1.0 - q * q)) * w);
+        a1More = -2.0 * exp(-1.0 * q * w) * ma.cosh(sqrt(max(.0, q * q - 1.0)) * w);
+        a1 = ba.if(q <= 1.0, a1Less, a1More);
+        a2 = exp(-2.0 * q * w);
+        phi0 = 1.0 - sin(.5 * w) ^ 2.0;
+        phi1 = sin(.5 * w) ^ 2.0;
+        phi2 = 4.0 * phi0 * phi1;
+        A0 = (1.0 + a1 + a2) ^ 2.0;
+        A1 = (1.0 - a1 + a2) ^ 2.0;
+        A2 = -4.0 * a2;
+        B0 = A0;
+        R1 = (A0 * phi0 + A1 * phi1 + A2 * phi2) * G * G;
+        R2 = (-1.0 * A0 + A1 + 4.0 * (phi0 - phi1) * A2) * G * G;
+        B1 = R2 + B0 + 4.0 * (phi1 - phi0) * B2;
+        B2 = (R1 - R2 * phi1 - B0) / (4.0 * phi1 * phi1);
+        W = .5 * (sqrt(B0) + sqrt(B1));
+        b0 = .5 * (W + sqrt(W * W + B2));
+        b1 = .5 * (sqrt(B0) - sqrt(B1));
+        b2 = (-1.0 * B2) / (4.0 * b0);
+    };
 
 
 /*******************************************************************************


### PR DESCRIPTION
Vicanek's decramped second-order resonant filters, which require no oversampling, although they require double-precision.
![matchedLP](https://github.com/user-attachments/assets/f9fb7a2e-1671-492d-92db-f42b907cc92a)
![matchedPeaking](https://github.com/user-attachments/assets/fdef868f-e7b6-4575-97de-ce201655b04d)
![matchedBP](https://github.com/user-attachments/assets/82039363-c136-4385-afda-a5ceeaeb4181)
![matchedHP](https://github.com/user-attachments/assets/2b83691f-ac77-45f5-a22c-e5ac249c181d)
