### PR TITLE
use ba.pick/pickN helpers to  simplify os.sidebands(), pm.rk_solve() and ba.ifNcNo() 

### DIFF
--- a/basics.lib
+++ b/basics.lib
@@ -1672,10 +1672,10 @@ declare ifNc license "MIT-style STK-4.3 license";
 ifNcNo(Nc,No) = si.bus(Ni) <: par(no,No, slice(no) : ifNc(Nc))
 with {
     Ni = Nc*No + Nc+No;
-    slice(no) = route(Ni,2*Nc+1, (par(nc,Nc, ct(nc,no)),else(no)));
-    ct(nc,no) = nc*(No+1)+1,    2*nc+1,    // cond[nc]
-                nc*(No+1)+2+no, 2*nc+2;    // then[nc][no]
-    else(no)  = Nc*(No+1)+1+no, 2*Nc+1;    // else[no]
+    slice(no) = pickN(Ni, (par(nc,Nc, ct(nc,no)), else(no)));
+    ct(nc,no) = nc*(No+1)+0,    // cond[nc]
+                nc*(No+1)+1+no; // then[nc][no]
+    else(no)  = Nc*(No+1)+0+no; // else[no]
 };
 
 declare ifNcNo author "Oleg Nesterov";

--- a/oscillators.lib
+++ b/oscillators.lib
@@ -1368,8 +1368,7 @@ sidebands(vs, c0,s0)
     : seq(n, outputs(vs)-1, add(vn(n+1)))
     : _,_, !,!, !,!
 with {
-    // ba.take(n+1, vs)
-    vn(n) = vs : route(outputs(vs),1, n+1,1);
+    vn = ba.pick(vs);
 
     add(vn, co,so, cn_2,cn_1, sn_2,sn_1) =
         co+cn*vn, so+sn*vn, cn_1,cn, sn_1,sn

--- a/physmodels.lib
+++ b/physmodels.lib
@@ -4075,12 +4075,9 @@ with {
     O = outputs(ts);
     N = outputs(eq);
 
-    // same as ba.take(n+1,l) but more efficient
-    take(l,n) = l : route(outputs(l),1, n+1, 1);
-
     // solution for the current tick, calculated at the previous
     // tick or `iv` if T == 0 (first tick).
-    curr = par(i,N, ck_iv(take(iv,i))) with {
+    curr = par(i,N, ck_iv(ba.pick(iv,i))) with {
         ck_iv = case {
             (0) => _; (0.0) => _; // optimization
             (x) => select2(ba.time, x);
@@ -4091,7 +4088,7 @@ with {
     // solution for T+h time. And we can't just add `: par(i,N,mem)`,
     // this won't work at T == 0 time if iv != 0, see ck_iv above.
     doit = (si.bus(N) <: tick, si.bus(N)) ~ curr :
-        si.block(N), si.bus(N);
+            si.block(N), si.bus(N);
 
     // repeat `step` `ni` times using the `h/ni` time step, outputs
     // the solution for T+h time (next tick).
@@ -4107,8 +4104,8 @@ with {
             push = ro.interleave(N,K) : par(i,N, vec) : eqt;
         };
 
-        vec(K) = _, par(i,K, *(take(ks, K*(K-1)/2 + i))) :> _;
-        eqt(K) = eq(t + h * take(ts, K)) : par(i,N, *(h));
+        vec(K) = _, par(i,K, *(ba.pick(ks, K*(K-1)/2 + i))) :> _;
+        eqt(K) = eq(t + h * ba.pick(ts, K)) : par(i,N, *(h));
     };
 };
 


### PR DESCRIPTION
os.sidebands(), pm.rk_solve() and ba.ifNcNo() can re-use ba.pick/pickN helpers instead of
re-implementing this code by hand.

No changes in generated code.