### PR TITLE
Simplify feedback loop in hysteresis core

### DIFF
--- a/hysteresis.lib
+++ b/hysteresis.lib
@@ -70,6 +70,7 @@ fi = library("filters.lib");
 
 declare name "Faust Hysteresis Library";
 declare author "Thomas Mandolini";
+declare contributor "Bart Brouns a.k.a magnetophon";
 declare version "1.0.1";
 
 //========================== Jiles-Atherton Core =====================================
@@ -155,10 +156,14 @@ with {
 
     // 4x cascaded substeps with cubic Hermite interpolation
     // Uses H history for smooth tangent-matched curve between samples
-    core(H_in) = (loop ~ (_, _, _)) : (_, !, !)
+    core(H_in) = loop ~ _
     with {
-        loop(M_prev, H_prev, H_prev_prev) = M4, H_in, H_prev
+        loop(M_prev) = M4
         with {
+            // H history via delay operators
+            H_prev = H_in@1;
+            H_prev_prev = H_in@2;
+
             // Tangent estimation (Catmull-Rom style)
             dH_prev = H_prev - H_prev_prev;
             dH_in = H_in - H_prev;


### PR DESCRIPTION
## Summary

- Use single feedback for M with `@` delays for H history instead of triple feedback loop
- Added `declare contributor` credit

## Changes

```faust
// OLD
core(H_in) = (loop ~ (_, _, _)) : (_, !, !)
with {
    loop(M_prev, H_prev, H_prev_prev) = M4, H_in, H_prev

// NEW
core(H_in) = loop ~ _
with {
    loop(M_prev) = M4
    with {
        H_prev = H_in@1;
        H_prev_prev = H_in@2;
```

## Rationale

H_prev and H_prev_prev are just delayed inputs, not recursive state. Only M needs feedback. The `@` operator achieves the same delay without extra feedback wiring.

Functionally identical - A/B tested, sounds the same.

## Credit

Suggested by: Bart Brouns a.k.a magnetophon