### PR TITLE
Add interpolators and mel helpers

### DIFF
--- a/basics.lib
+++ b/basics.lib
@@ -323,6 +323,57 @@ midikey2hz(mk) = 440.0*pow(2.0, (mk-69.0)/12.0);
 hz2midikey(freq) = 12.0*ma.log2(freq/440.0) + 69.0;
 
 
+//-------`(ba.)hz2mel`----------
+// Converts a frequency in Hz to the mel perceptual-pitch scale.
+// Uses the O'Shaughnessy (1987) formula `2595 * log10(1 + f/700)`. Useful with
+// `mel2hz` and `it.interpolate_mel` for spacing things the way the ear hears pitch.
+//
+// #### Usage
+//
+// ```
+// hz2mel(freq) : _
+// ```
+//
+// Where:
+//
+// * `freq`: frequency in Hz
+//
+// #### Test
+// ```
+// ba = library("basics.lib");
+// hz2mel_test = ba.hz2mel(440.0);
+// ```
+//----------------------------
+declare hz2mel author "Bart Brouns";
+declare hz2mel licence "MIT";
+hz2mel(freq) = 2595.0*log10(1.0+freq/700.0);
+
+
+//-------`(ba.)mel2hz`----------
+// Converts a value on the mel perceptual-pitch scale back to a frequency in Hz.
+// Inverse of `hz2mel`, using `700 * (10^(m/2595) - 1)`.
+//
+// #### Usage
+//
+// ```
+// mel2hz(mel) : _
+// ```
+//
+// Where:
+//
+// * `mel`: value on the mel scale
+//
+// #### Test
+// ```
+// ba = library("basics.lib");
+// mel2hz_test = ba.mel2hz(1000.0);
+// ```
+//----------------------------
+declare mel2hz author "Bart Brouns";
+declare mel2hz licence "MIT";
+mel2hz(mel) = 700.0*(pow(10.0, mel/2595.0)-1.0);
+
+
 //-------`(ba.)semi2ratio`----------
 // Converts semitones in a frequency multiplicative ratio.
 // `semi2ratio` is a standard Faust function.

--- a/interpolators.lib
+++ b/interpolators.lib
@@ -276,6 +276,216 @@ declare interpolate_cosine licence "MIT";
 interpolate_cosine(dv,v0,v1) = v0 + a2*(v1-v0) with { a2 = 0.5 * (1.0 - cos(dv*ma.PI)); };
 
 
+//-------`(it.)interpolate_logarithmic`----------
+// Logarithmic (exponential) interpolation between 2 values.
+// The output traces a constant-ratio (geometric) curve from `v0` to `v1`, so it is
+// the natural choice for perceptually even sweeps of quantities such as frequency or
+// amplitude. Both bounds must be strictly positive and have the same sign.
+// Used for pitch and frequency sweeps and for octave-spaced oscillator or filter
+// banks, where equal steps should mean equal pitch ratios rather than equal Hz.
+//
+// #### Usage
+//
+// ```
+// interpolate_logarithmic(dv,v0,v1) : _
+// ```
+//
+// Where:
+//
+// * `dv`: in the fractional value in [0..1] range
+// * `v0`: is the first value (same sign as `v1`, != 0)
+// * `v1`: is the second value (same sign as `v0`, != 0)
+//
+// #### Test
+// ```
+// it = library("interpolators.lib");
+// interpolate_logarithmic_test = it.interpolate_logarithmic(0.5, 100.0, 10000.0);
+// ```
+//--------------------------------------------
+declare interpolate_logarithmic author "Bart Brouns";
+declare interpolate_logarithmic licence "MIT";
+
+interpolate_logarithmic(dv,v0,v1) = v0*pow(v1/v0, dv);
+
+
+//-------`(it.)interpolate_power`----------
+// Power (skewed) interpolation between 2 values.
+// Linear interpolation shaped by raising the fraction to the power `p`: `p = 1` is
+// linear, `p > 1` biases the curve toward `v0`, and `0 < p < 1` biases it toward `v1`.
+// Unlike `interpolate_logarithmic`, the bounds may be any values (including 0 and
+// opposite signs). `p` is the first argument so it can be partially applied to obtain a
+// `(dv,v0,v1)` interpolator.
+// Used for fader and volume taper laws (an audio-taper pot is roughly `p = 2..3`) and
+// for velocity- or expression-to-amplitude curves.
+//
+// #### Usage
+//
+// ```
+// interpolate_power(p,dv,v0,v1) : _
+// ```
+//
+// Where:
+//
+// * `p`: the skew exponent (p > 0); 1 is linear, > 1 biases toward `v0`, < 1 toward `v1`
+// * `dv`: in the fractional value in [0..1] range
+// * `v0`: is the first value
+// * `v1`: is the second value
+//
+// #### Test
+// ```
+// it = library("interpolators.lib");
+// interpolate_power_test = it.interpolate_power(2.0, 0.5, 0.0, 1.0);
+// ```
+//--------------------------------------------
+declare interpolate_power author "Bart Brouns";
+declare interpolate_power licence "MIT";
+
+interpolate_power(p,dv,v0,v1) = v0+(v1-v0)*pow(dv, p);
+
+
+//-------`(it.)interpolate_exponential`----------
+// Exponential (constant-rate) interpolation between 2 values.
+// Shapes the fraction through `(exp(k*dv)-1)/(exp(k)-1)` and then interpolates
+// linearly between `v0` and `v1` by that shaped fraction. `k` sets the curvature:
+// `k > 0` clusters the values near `v0`, `k < 0` clusters them near `v1`, and as
+// `k -> 0` the curve approaches `interpolate_linear` (guarded so exactly 0 does not
+// divide by 0). Because it shapes the fraction rather than the ratio, the bounds may
+// be any values (including 0 and opposite signs), unlike `interpolate_logarithmic`.
+// `k` is the first argument so it can be partially applied to obtain a `(dv,v0,v1)`
+// interpolator.
+// Used for natural-sounding envelope segments: the curve matches RC capacitor
+// charge/discharge, giving analog-style attack and decay/release shapes.
+//
+// #### Usage
+//
+// ```
+// interpolate_exponential(k,dv,v0,v1) : _
+// ```
+//
+// Where:
+//
+// * `k`: the curvature; > 0 clusters near `v0`, < 0 near `v1`, -> 0 approaches linear
+// * `dv`: in the fractional value in [0..1] range
+// * `v0`: is the first value
+// * `v1`: is the second value
+//
+// #### Test
+// ```
+// it = library("interpolators.lib");
+// interpolate_exponential_test = it.interpolate_exponential(3.0, 0.5, 0.0, 1.0);
+// ```
+//--------------------------------------------
+declare interpolate_exponential author "Bart Brouns";
+declare interpolate_exponential licence "MIT";
+
+interpolate_exponential(k,dv,v0,v1) = v0+(v1-v0)*shaped
+with {
+    // avoid k==0 -> 0/0 by clamping |k| to a small floor, keeping its sign
+    safeK = select2(abs(k)>1e-9, 1e-9*((k>=0)*2-1), k);
+    shaped = (exp(safeK*dv)-1.0)/(exp(safeK)-1.0);
+};
+
+
+//-------`(it.)interpolate_smoothstep`----------
+// Smoothstep (3rd-order, C1) interpolation between 2 values.
+// Eases in and out with zero slope at both ends, using the classic polynomial
+// `3*dv^2 - 2*dv^3`. Similar in spirit to `interpolate_cosine` but polynomial rather
+// than trigonometric, with slightly gentler shoulders. This is the curve most people
+// mean by "ease in/out".
+// Used to de-zipper control signals (gain, pan, cutoff) without clicks: the zero slope
+// at each end removes the discontinuity a linear ramp leaves at its corners.
+//
+// #### Usage
+//
+// ```
+// interpolate_smoothstep(dv,v0,v1) : _
+// ```
+//
+// Where:
+//
+// * `dv`: in the fractional value in [0..1] range
+// * `v0`: is the first value
+// * `v1`: is the second value
+//
+// #### Test
+// ```
+// it = library("interpolators.lib");
+// interpolate_smoothstep_test = it.interpolate_smoothstep(0.5, 0.0, 1.0);
+// ```
+//--------------------------------------------
+declare interpolate_smoothstep author "Bart Brouns";
+declare interpolate_smoothstep licence "MIT";
+
+interpolate_smoothstep(dv,v0,v1) = v0+(v1-v0)*(dv*dv*(3.0-2.0*dv));
+
+
+//-------`(it.)interpolate_smootherstep`----------
+// Smootherstep (5th-order, C2) interpolation between 2 values.
+// Like `interpolate_smoothstep` but with zero first AND second derivative at both
+// ends, using `6*dv^5 - 15*dv^4 + 10*dv^3`. The smoothest of the symmetric S-curves;
+// use it when even the rate of change should have no visible kink at the bounds.
+// Used for morphs or long automation moves where smoothstep is not enough: the
+// continuous acceleration keeps a slow filter or crossfade from audibly snapping into
+// motion or to a stop.
+//
+// #### Usage
+//
+// ```
+// interpolate_smootherstep(dv,v0,v1) : _
+// ```
+//
+// Where:
+//
+// * `dv`: in the fractional value in [0..1] range
+// * `v0`: is the first value
+// * `v1`: is the second value
+//
+// #### Test
+// ```
+// it = library("interpolators.lib");
+// interpolate_smootherstep_test = it.interpolate_smootherstep(0.5, 0.0, 1.0);
+// ```
+//--------------------------------------------
+declare interpolate_smootherstep author "Bart Brouns";
+declare interpolate_smootherstep licence "MIT";
+
+interpolate_smootherstep(dv,v0,v1) = v0+(v1-v0)*(dv*dv*dv*(dv*(dv*6.0-15.0)+10.0));
+
+
+//-------`(it.)interpolate_mel`----------
+// Mel-scale (perceptual pitch) interpolation between 2 frequencies.
+// Unlike the other interpolators, `v0` and `v1` are frequencies in Hz: they are
+// converted to the mel scale with `ba.hz2mel`, interpolated linearly there, and
+// converted back with `ba.mel2hz`. This spreads frequencies the way the ear hears
+// pitch, which is the right spacing for filterbank or oscillator-bank center
+// frequencies.
+// Used to choose band center frequencies for a filterbank or vocoder, or bin
+// groupings for spectral analysis, so the bands track perceived pitch.
+//
+// #### Usage
+//
+// ```
+// interpolate_mel(dv,v0,v1) : _
+// ```
+//
+// Where:
+//
+// * `dv`: in the fractional value in [0..1] range
+// * `v0`: is the first frequency in Hz
+// * `v1`: is the second frequency in Hz
+//
+// #### Test
+// ```
+// it = library("interpolators.lib");
+// interpolate_mel_test = it.interpolate_mel(0.5, 100.0, 8000.0);
+// ```
+//--------------------------------------------
+declare interpolate_mel author "Bart Brouns";
+declare interpolate_mel licence "MIT";
+
+interpolate_mel(dv,v0,v1) = ba.mel2hz(interpolate_linear(dv, ba.hz2mel(v0), ba.hz2mel(v1)));
+
+
 //=========================Four points interpolation functions============================
 //========================================================================================
 


### PR DESCRIPTION
Six new two-point interpolators in `interpolators.lib`, alongside the existing `interpolate_linear`/`interpolate_cosine` and following the same `interp(dv, v0, v1)` shape (fraction first):

- `interpolate_logarithmic` — geometric sweep; pitch/frequency and octave-spaced banks.
- `interpolate_power` — power-skewed lerp; fader/taper laws, velocity curves.
- `interpolate_exponential` — exponentially-shaped lerp; analog-style envelope segments.
- `interpolate_smoothstep` — C1 ease in/out; click-free control-signal de-zippering.
- `interpolate_smootherstep` — C2 ease; longer morphs where smoothstep isn't smooth enough.
- `interpolate_mel` — interpolates two Hz values in mel space; filterbank/vocoder bands.

Plus `ba.hz2mel` / `ba.mel2hz` in `basics.lib`, next to the other frequency conversions (`midikey2hz` etc.) — `interpolate_mel` calls them across the `it`/`ba` boundary, which Faust resolves fine since the two libraries already import each other.

`interpolate_power` and `interpolate_exponential` take their shape parameter first, which is the one break from fraction-first: it lets them be partially applied into a standard `(dv, v0, v1)` interpolator.

Each function has the usual doc block and `_test` binding, and the whole set compiles under `faust -wall`. Licensed MIT per-function, matching the existing interpolators.